### PR TITLE
Issue 79: Unify our telemetry, MTP, and xUnit 4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
         shell: pwsh
         run: ./devops.ps1 build
       - name: Validate DevOps artefact infrastructure
+        if: matrix.framework == 'net10.0'
         shell: pwsh
         run: pwsh ./scripts/devops/validation/artifacts-smoke.ps1
       - name: Test deterministic suites

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,8 +63,8 @@ jobs:
         run: ./devops.ps1 coverage -Framework net10.0 -Clean
       - uses: actions/upload-artifact@v7
         with:
-          name: coverage-results
-          path: coverage-results/**/*.coverage.cobertura.*.xml
+          name: coverage-runs
+          path: artifacts/coverage/runs
           if-no-files-found: error
 
   windows-tests:
@@ -137,12 +137,12 @@ jobs:
           dotnet-quality: preview
       - uses: actions/download-artifact@v7
         with:
-          name: coverage-results
-          path: coverage-results
+          name: coverage-runs
+          path: artifacts/coverage/runs
       - name: Build docs
         shell: pwsh
         run: ./devops docs build -SkipBenchmarks
       - uses: actions/upload-artifact@v7
         with:
           name: leancorpus-docs-site
-          path: docs/site
+          path: artifacts/docs/site

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Build solution
         shell: pwsh
         run: ./devops.ps1 build
+      - name: Validate DevOps artefact infrastructure
+        shell: pwsh
+        run: pwsh ./scripts/devops/validation/artifacts-smoke.ps1
       - name: Test deterministic suites
         shell: pwsh
         env: { CHAOS_ITERATIONS: 25 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,7 @@ name: Build
 on:
   push:
     branches: [main, '[0-9]*', 'stabilise/**']
-  pull_request:
-    branches: [main, '[0-9]*', 'stabilise/**']
+  pull_request: {}
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,4 +57,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy ${{ github.event_name == 'workflow_dispatch' && 'docs/site' || 'docs-site' }} --project-name=leanlucene --branch=${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.workflow_run.head_branch }} --commit-dirty=true
+          command: pages deploy ${{ github.event_name == 'workflow_dispatch' && 'artifacts/docs/site' || 'docs-site' }} --project-name=leanlucene --branch=${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.workflow_run.head_branch }} --commit-dirty=true

--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -32,5 +32,5 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: benchmark-results
-          path: BenchmarkDotNet.Artifacts/**
+          path: artifacts/benchmark/runs
           if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,7 @@
 # Source-generator output
 *.g.cs
 # Benchmark results (ignore output, keep data)
-bench/*
-bench/data/*.tar.gz
+bench/
 coverage-report/
 coverage-results/
 StrykerOutput/
@@ -82,7 +81,7 @@ BenchmarkDotNet.Artifacts/
 # .NET
 project.lock.json
 project.fragment.lock.json
-artifacts/
+/artifacts/
 
 # Tye
 .tye/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,7 +144,8 @@ The detailed rules live in the [DevOps and tests guide](src/devops/CONTRIBUTING.
 ## Generated files
 
 > [!WARNING]
-> Do not manually edit `bin`, `obj`, `coverage-results`, BenchmarkDotNet artefacts or generated documentation. Change the source, configuration or generator instead.
+> Do not manually edit generated content under `artifacts/`. Change the source,
+> configuration or generator instead.
 
 ## Before submitting
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
+    <ArtifactsPath>$(MSBuildThisFileDirectory)artifacts</ArtifactsPath>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,6 +28,7 @@
     <PackageVersion Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.661903" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CrashDump" Version="2.3.3" />
     <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="2.3.3" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.GitHubActionsReport" Version="2.4.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
@@ -38,6 +39,9 @@
     <PackageVersion Include="TngTech.ArchUnitNET" Version="0.13.4" />
     <PackageVersion Include="TngTech.ArchUnitNET.xUnitV3" Version="0.13.4" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="4.0.0" />
+    <PackageVersion Include="xunit.v3.aot" Version="4.0.0" />
+    <PackageVersion Include="xunit.v3.aot.mtp-v2" Version="4.0.0" />
+    <PackageVersion Include="xunit.v3.assert.aot" Version="4.0.0" />
     <PackageVersion Include="ZstdSharp.Port" Version="0.8.8" />
   </ItemGroup>
 </Project>

--- a/changelog/unreleased.md
+++ b/changelog/unreleased.md
@@ -11,6 +11,7 @@
 * Hardened Windows lifecycle tests and made repeated MTP test diagnostics aggregate by semantic test identity across executions.
 * Fixed CI-prepared test executable discovery, empty-telemetry reporting and central-output metadata tests.
 * Fixed benchmark report schema collisions, result-based benchmark exit codes, coverage status propagation, current-commit documentation coverage, and interrupted artefact-run finalisation.
+* Hardened benchmark documentation evidence selection, dirty-worktree coverage provenance, shared coverage/test run identity, best-effort test telemetry, and Windows stress-test diagnostics.
 
 ### Removed
 

--- a/changelog/unreleased.md
+++ b/changelog/unreleased.md
@@ -1,6 +1,10 @@
 ### Added
 
+* Added unified DevOps run manifests, xUnit-correlated test telemetry, runtime diagnostics, CTRF and GitHub Actions reporting, and safe `clean` and package-manifest workflows under `artifacts/`.
+
 ### Changed
+
+* Consolidated build, test, coverage, benchmark, diagnostic and documentation output under the SDK artefact root; normal benchmark runs now cover Core, Rowles.Text and compression in one provenance-scoped run, and Native AOT smoke tests use the stable xUnit 4 MTP v2 stack.
 
 ### Fixed
 

--- a/changelog/unreleased.md
+++ b/changelog/unreleased.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 * Hardened Windows lifecycle tests and made repeated MTP test diagnostics aggregate by semantic test identity across executions.
+* Fixed CI-prepared test executable discovery, empty-telemetry reporting and central-output metadata tests.
 
 ### Removed
 

--- a/changelog/unreleased.md
+++ b/changelog/unreleased.md
@@ -10,6 +10,7 @@
 
 * Hardened Windows lifecycle tests and made repeated MTP test diagnostics aggregate by semantic test identity across executions.
 * Fixed CI-prepared test executable discovery, empty-telemetry reporting and central-output metadata tests.
+* Fixed benchmark report schema collisions, result-based benchmark exit codes, coverage status propagation, current-commit documentation coverage, and interrupted artefact-run finalisation.
 
 ### Removed
 

--- a/docs/articles/ADRs/ADR030-unified-devops-artefact-and-test-evidence.md
+++ b/docs/articles/ADRs/ADR030-unified-devops-artefact-and-test-evidence.md
@@ -1,0 +1,84 @@
+---
+adr: ADR030
+title: "DevOps owns unified artefact and test evidence"
+date: 2026-09-07
+status: Accepted
+version-added: vNext
+summary: "Build, test, coverage, benchmark, diagnostics, package and documentation output share one artefact root and provenance contract."
+areas: [devops, testing, telemetry, benchmarks]
+---
+
+# ADR030: DevOps owns unified artefact and test evidence
+
+- **Date:** 2026-09-07
+- **Status:** Accepted
+
+## Context
+
+LeanCorpus development workflows historically wrote generated output to several
+unrelated repository directories. Test results, diagnostics, coverage and
+benchmark measurements used different run identities and provenance formats.
+This made failed or interrupted work difficult to correlate and forced CI and
+documentation tooling to know subsystem-specific paths.
+
+xUnit 4 and Microsoft Testing Platform v2 provide test-level parallelisation,
+explicit-test control, warnings, structured reports, GitHub reporting and a
+stable Native AOT runner. LeanCorpus already exposes BCL activities and meters,
+but test execution did not associate those signals with an individual test.
+
+## Decision
+
+The .NET SDK `ArtifactsPath` is the sole root for build, intermediate, package
+and publish output. DevOps extends that same `artifacts/` root for test,
+coverage, benchmark, diagnostics, documentation and temporary output.
+
+Every run-capable DevOps subsystem writes a common `run.json` envelope when it
+starts and completes it without replacing Git, framework, operating-system or
+machine provenance. DevOps supplies the run identity and target directory to
+child processes through a small `LEANCORPUS_*` environment contract.
+
+Normal test projects use xUnit 4 on MTP v2. A repository-owned configuration
+sets conservative defaults. DevOps selects full test-case parallelism only for
+unit and explicit stress profiles; integration remains collection-parallel and
+existing collection-level global-state exclusions remain authoritative.
+Explicit tests are excluded unless requested. Ordinary tests are never retried.
+
+Diagnostic test processes install first-party `ActivityListener` and
+`MeterListener` instances. Each test owns a `leancorpus.test` root activity and
+is indexed by trace identity, preventing concurrent tests from receiving one
+another's signals. Raw activity and metric records are streamed during the
+test, summaries and warnings are attached through `TestContext`, and runtime
+measurements remain at execution scope. Standard benchmark runs keep listeners
+disabled so diagnostic overhead cannot contaminate normal measurements.
+
+`./devops benchmark` owns one run containing the Core, Rowles.Text and
+compression projects. A failure in one project does not remove earlier output.
+Generated benchmark documentation discovers all three families from those run
+directories.
+
+## Rationale
+
+The SDK already implements collision-safe project, configuration, framework and
+RID output layouts, so reproducing that logic in PowerShell would create a
+second source of truth. One run envelope makes local, CI and documentation
+consumers independent of runner-specific default directories.
+
+Direct BCL listeners preserve Native AOT compatibility and avoid depending on
+the experimental MTP OpenTelemetry entry-point replacement. Trace identity is
+the only safe correlation key once tests may execute concurrently.
+
+## Consequences
+
+- Generated workflow output belongs under `artifacts/`; legacy output paths are
+  retained only as historical references.
+- `scripts/devops/artifacts/` owns path resolution, atomic manifests and bounded
+  cleaning. Full cleaning is explicit; default cleaning preserves packages,
+  benchmark history and downloaded benchmark data.
+- Test projects share linked diagnostics sources and the centrally managed
+  GitHub Actions reporter dependency. This is test infrastructure and does not
+  change shipped LeanCorpus or Rowles.Text package APIs.
+- The Native AOT smoke project uses released xUnit 4 AOT and MTP v2 packages.
+- Raw diagnostic telemetry is intentionally more expensive and is confined to
+  diagnostic, flaky and stress profiles. CI retains summaries.
+- `./devops pack` writes packages and a checksum manifest to
+  `artifacts/package/release/`.

--- a/docs/articles/ADRs/ADR030-unified-devops-artefact-and-test-evidence.md
+++ b/docs/articles/ADRs/ADR030-unified-devops-artefact-and-test-evidence.md
@@ -50,6 +50,9 @@ another's signals. Raw activity and metric records are streamed during the
 test, summaries and warnings are attached through `TestContext`, and runtime
 measurements remain at execution scope. Standard benchmark runs keep listeners
 disabled so diagnostic overhead cannot contaminate normal measurements.
+There is no benchmark `-Diagnostics` mode in this contract; benchmark-process
+telemetry requires a separate BenchmarkDotNet integration before it can be
+claimed as evidence.
 
 `./devops benchmark` owns one run containing the Core, Rowles.Text and
 compression projects. A failure in one project does not remove earlier output.

--- a/docs/articles/ADRs/index.md
+++ b/docs/articles/ADRs/index.md
@@ -40,6 +40,7 @@ _description: Recorded LeanCorpus architecture decisions and their status.
 <tr><td><a href="ADR027-memory-mapped-operation-lifetimes.md">027</a></td><td>2026-08-21</td><td>Accepted</td><td></td><td><a href="ADR027-memory-mapped-operation-lifetimes.md">Memory mappings drain active operations before reclamation</a></td><td></td></tr>
 <tr><td><a href="ADR028-token-graph-analysis.md">028</a></td><td>2026-08-21</td><td>Accepted</td><td></td><td><a href="ADR028-token-graph-analysis.md">Token graphs remain an analysis concern and flatten before postings</a></td><td></td></tr>
 <tr><td><a href="ADR029-platform-filesystem-durability.md">029</a></td><td>2026-08-21</td><td>Accepted</td><td></td><td><a href="ADR029-platform-filesystem-durability.md">Platform-specific durability stays behind the Store boundary</a></td><td></td></tr>
+<tr><td><a href="ADR030-unified-devops-artefact-and-test-evidence.md">030</a></td><td>2026-09-07</td><td>Accepted</td><td></td><td><a href="ADR030-unified-devops-artefact-and-test-evidence.md">DevOps owns unified artefact and test evidence</a></td><td></td></tr>
 </tbody>
 </table>
 </div>

--- a/docs/changelog/unreleased.md
+++ b/docs/changelog/unreleased.md
@@ -11,6 +11,7 @@
 * Hardened Windows lifecycle tests and made repeated MTP test diagnostics aggregate by semantic test identity across executions.
 * Fixed CI-prepared test executable discovery, empty-telemetry reporting and central-output metadata tests.
 * Fixed benchmark report schema collisions, result-based benchmark exit codes, coverage status propagation, current-commit documentation coverage, and interrupted artefact-run finalisation.
+* Hardened benchmark documentation evidence selection, dirty-worktree coverage provenance, shared coverage/test run identity, best-effort test telemetry, and Windows stress-test diagnostics.
 
 ### Removed
 

--- a/docs/changelog/unreleased.md
+++ b/docs/changelog/unreleased.md
@@ -1,6 +1,10 @@
 ### Added
 
+* Added unified DevOps run manifests, xUnit-correlated test telemetry, runtime diagnostics, CTRF and GitHub Actions reporting, and safe `clean` and package-manifest workflows under `artifacts/`.
+
 ### Changed
+
+* Consolidated build, test, coverage, benchmark, diagnostic and documentation output under the SDK artefact root; normal benchmark runs now cover Core, Rowles.Text and compression in one provenance-scoped run, and Native AOT smoke tests use the stable xUnit 4 MTP v2 stack.
 
 ### Fixed
 

--- a/docs/changelog/unreleased.md
+++ b/docs/changelog/unreleased.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 * Hardened Windows lifecycle tests and made repeated MTP test diagnostics aggregate by semantic test identity across executions.
+* Fixed CI-prepared test executable discovery, empty-telemetry reporting and central-output metadata tests.
 
 ### Removed
 

--- a/docs/changelog/unreleased.md
+++ b/docs/changelog/unreleased.md
@@ -10,6 +10,7 @@
 
 * Hardened Windows lifecycle tests and made repeated MTP test diagnostics aggregate by semantic test identity across executions.
 * Fixed CI-prepared test executable discovery, empty-telemetry reporting and central-output metadata tests.
+* Fixed benchmark report schema collisions, result-based benchmark exit codes, coverage status propagation, current-commit documentation coverage, and interrupted artefact-run finalisation.
 
 ### Removed
 

--- a/docs/contributors/devops-entry-point.md
+++ b/docs/contributors/devops-entry-point.md
@@ -39,6 +39,8 @@ Callers should not need to reproduce long `dotnet` command lines or know which g
 | `docs` | Generate API metadata and build or serve DocFX | `./devops docs -SkipBenchmarks` |
 | `server start` | Start the Community Server in the foreground on loopback, or use `-External` for trusted-network access | `./devops server start -External` |
 | `benchmarks docs` | Regenerate benchmark documentation pages | `./devops benchmarks docs` |
+| `clean` | Remove selected DevOps-owned output | `./devops clean test` |
+| `pack` | Pack release artefacts and write a checksum manifest | `./devops pack` |
 
 Use `benchmark` for running measurements and `benchmarks docs` for publishing existing result artefacts. The plural command is intentionally not a second benchmark runner.
 
@@ -86,7 +88,7 @@ flowchart LR
     D --> R
     J --> R
     X --> R
-    R --> O[bench machine and run artefacts]
+    R --> O[one artifacts benchmark run]
 ```
 
 `-Dry` prints the resolved command. Use it when changing routing or investigating a remote invocation.
@@ -103,7 +105,7 @@ The build sequence can:
 
 1. regenerate the feature-comparison index from item front matter;
 2. regenerate the ADR index;
-3. copy canonical repository guides into the ignored `docs/.generated` staging tree;
+3. stage canonical repository guides under `artifacts/docs/generated/repository`;
 4. regenerate benchmark pages unless `-SkipBenchmarks` is set;
 5. regenerate coverage HTML when source data exists unless `-SkipCoverage` is set;
 6. clear and regenerate DocFX API metadata;
@@ -113,7 +115,10 @@ The build sequence can:
 
 `-SkipBenchmarks` avoids an expensive or unrelated benchmark-report refresh. It does not skip conceptual pages or API metadata.
 
-DocFX warnings are grouped by code in the console. Complete metadata and build diagnostics are written as JSON lines to `artifacts/docs/docfx-metadata.jsonl` and `artifacts/docs/docfx-build.jsonl`. A status line is printed every 30 seconds while DocFX is running so a slow API pass does not appear stuck.
+DocFX warnings are grouped by code in the console. Complete metadata and build
+diagnostics are written as JSON lines under `artifacts/docs/diagnostics/`. A
+status line is printed every 30 seconds while DocFX is running so a slow API
+pass does not appear stuck.
 
 Generated repository copies, API, site, benchmark, and coverage output must remain generated. Change their canonical source or generator instead of patching the output.
 

--- a/docs/contributors/documentation.md
+++ b/docs/contributors/documentation.md
@@ -4,20 +4,15 @@ The site is built by DocFX from Markdown, YAML navigation, XML API comments, gen
 
 ## Source and generated content
 
-Edit the Markdown source and templates. Do not edit generated output in:
-
-- `docs/.generated`;
-- `docs/site`;
-- `docs/api`;
-- `docs/bench`;
-- `docs/coverage`;
-- `bin` or `obj`.
+Edit the Markdown source and templates. Do not edit generated output beneath
+`artifacts/`, including `artifacts/docs/api`, `artifacts/docs/site`, generated
+benchmark and coverage pages, or SDK `bin` and `obj` output.
 
 API reference pages are generated from XML documentation. If a public member is unclear, improve its XML comment as well as any conceptual guide.
 
 The feature comparison lives in the Markdown pages under `docs/articles/features`. User-visible feature additions or removals should update the relevant comparison page where applicable. Keep Lucene.NET 4.8 and current Java Lucene as separate comparisons, and use `◐` only for comparable rather than API-equivalent behaviour.
 
-Repository READMEs and contribution guides remain at their owning repository paths so they work on GitHub. The documentation build copies the selected files into `docs/.generated`, rewrites local links for their site destinations, and adds a source notice. Update the source-to-destination map in `Copy-RepositoryDocumentation` when adding or moving one of these guides.
+Repository READMEs and contribution guides remain at their owning repository paths so they work on GitHub. The documentation build stages the selected files under `artifacts/docs/generated/repository`, rewrites local links for their site destinations, and adds a source notice. Update the source-to-destination map in `Copy-RepositoryDocumentation` when adding or moving one of these guides.
 
 ## Navigation
 
@@ -58,7 +53,7 @@ Build the site without regenerating benchmarks:
 ./devops docs -SkipBenchmarks
 ```
 
-The console groups DocFX warnings by code rather than printing every instance. Full JSON-lines diagnostics are retained under `artifacts/docs`, and long DocFX stages report elapsed time every 30 seconds.
+The console groups DocFX warnings by code rather than printing every instance. Full JSON-lines diagnostics are retained under `artifacts/docs/diagnostics`, and long DocFX stages report elapsed time every 30 seconds.
 
 Resolve broken links, duplicate headings, invalid YAML, and Mermaid parse failures before handing off a documentation change. Generated HTML belongs to the build output and should not be committed manually.
 

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -23,7 +23,7 @@
           "src": "../src/core/Rowles.LeanCorpus.SourceGen"
         }
       ],
-      "dest": "api",
+      "dest": "../artifacts/docs/api",
       "filter": "filterConfig.yml",
       "namespaceLayout": "nested",
       "memberLayout": "separatePages",
@@ -34,7 +34,14 @@
   "build": {
     "content": [
       {
-        "files": [ "api/**.yml", "api/index.md" ]
+        "files": [ "**.yml" ],
+        "src": "../artifacts/docs/api",
+        "dest": "api"
+      },
+      {
+        "files": [ "index.md" ],
+        "src": "api",
+        "dest": "api"
       },
       {
         "files": [ "*.md", "toc.yml" ]
@@ -83,29 +90,36 @@
       },
       {
         "files": [ "**.md" ],
-        "src": ".generated"
+        "src": "../artifacts/docs/generated/repository",
+        "dest": ".generated"
       },
       {
         "files": [ "articles/**.md" ]
       },
       {
-        "files": [ "benchmarks/*.md" ]
+        "files": [ "*.md" ],
+        "src": "../artifacts/docs/generated/benchmarks",
+        "dest": "benchmarks"
       },
       {
         "files": [ "changelog/**.md" ]
       }
     ],
-    "output": "site",
+    "output": "../artifacts/docs/site",
     "template": [ "default", "modern", "templates/leancorpus" ],
     "resource": [
       {
         "files": [ "assets/**" ]
       },
       {
-        "files": [ "benchmarks/*.json", "benchmarks/benchmark-charts.js" ]
+        "files": [ "*.json", "benchmark-charts.js" ],
+        "src": "../artifacts/docs/generated/benchmarks",
+        "dest": "benchmarks"
       },
       {
-        "files": [ "coverage/**" ]
+        "files": [ "**" ],
+        "src": "../artifacts/docs/coverage",
+        "dest": "coverage"
       }
     ],
     "globalMetadata": {

--- a/docs/tips/03-benchmarking.md
+++ b/docs/tips/03-benchmarking.md
@@ -55,7 +55,8 @@ Use `-CorpusOnly` when a suite should use corpus-backed cases without synthetic 
 
 ## Output
 
-Runs are written beneath `bench/{machine}/...`.
+Normal runs are written beneath `artifacts/benchmark/runs/<run-id>/`, with one
+provenance envelope containing Core, Rowles.Text and compression results.
 
 | Artefact | Contents |
 |---|---|

--- a/docs/tips/03-benchmarking.md
+++ b/docs/tips/03-benchmarking.md
@@ -60,11 +60,12 @@ provenance envelope containing Core, Rowles.Text and compression results.
 
 | Artefact | Contents |
 |---|---|
-| `report.json` | Consolidated suites, statistics, allocation, GC, workload, and provenance |
+| `run-report.json` | Root orchestration status for the requested benchmark projects |
+| `core/report.json` | Core suites, statistics, allocation, GC, workload, and provenance |
 | Suite directories | BenchmarkDotNet Markdown, CSV, and JSON |
 | Machine `index.json` | Run inventory for generated documentation |
 
-Treat the raw BenchmarkDotNet artefacts and `report.json` as the evidence. Generated site pages are a presentation layer.
+Treat the raw BenchmarkDotNet artefacts, `run-report.json`, and `core/report.json` as the evidence. Generated site pages are a presentation layer.
 
 ## Interpret a result
 

--- a/scripts/benchmarks/generate-docs.ps1
+++ b/scripts/benchmarks/generate-docs.ps1
@@ -3,13 +3,13 @@
     Generates DocFX benchmark pages from BDN output files — one page per suite.
 
 .DESCRIPTION
-    For each machine directory under bench/, scans all completed runs and keeps the
+    Scans completed runs under artifacts/benchmark/runs and keeps the
     newest run per suite and writes one markdown page per suite into docs/benchmarks/.
 
     Run this before docfx build; docs.ps1 calls it automatically.
 
 .PARAMETER BenchDir
-    Path to the bench/ directory. Defaults to ../bench relative to the script.
+    Path to the benchmark run directory. Defaults to artifacts/benchmark/runs.
 
 .PARAMETER OutputDir
     Path to write the generated files. Defaults to ../docs/benchmarks.
@@ -28,11 +28,19 @@ $ErrorActionPreference = 'Stop'
 
 $repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
 
-if ([string]::IsNullOrEmpty($BenchDir))  { $BenchDir  = Join-Path $repoRoot 'bench' }
-if ([string]::IsNullOrEmpty($OutputDir)) { $OutputDir = Join-Path $repoRoot 'docs\benchmarks' }
+if ([string]::IsNullOrEmpty($BenchDir))  { $BenchDir  = Join-Path $repoRoot 'artifacts/benchmark/runs' }
+if ([string]::IsNullOrEmpty($OutputDir)) { $OutputDir = Join-Path $repoRoot 'artifacts\docs\generated\benchmarks' }
 
 $BenchDir  = [System.IO.Path]::GetFullPath($BenchDir)
 $OutputDir = [System.IO.Path]::GetFullPath($OutputDir)
+
+# Preserve the last published benchmark documentation until a newer run exists.
+# This keeps a clean checkout buildable while moving generated output out of docs/.
+[void][System.IO.Directory]::CreateDirectory($OutputDir)
+$publishedDirectory = Join-Path $repoRoot 'docs/benchmarks'
+foreach ($publishedFile in @(Get-ChildItem $publishedDirectory -File -ErrorAction SilentlyContinue)) {
+    Copy-Item -LiteralPath $publishedFile.FullName -Destination (Join-Path $OutputDir $publishedFile.Name) -Force
+}
 
 # ── Suite display names ───────────────────────────────────────────────────────
 
@@ -110,28 +118,16 @@ function Get-TableContent([string]$path) {
 
 # ── Collect runs ──────────────────────────────────────────────────────────────
 
-$machines = @(Get-ChildItem $BenchDir -Directory | Where-Object { $_.Name -ne 'data' } | Sort-Object Name)
-
-if ($machines.Count -eq 0) {
-    Write-Warning "No machine directories found in $BenchDir"
+if (-not (Test-Path $BenchDir)) {
+    Write-Warning "No benchmark runs found in $BenchDir"
     exit 0
 }
 
 # Map: suiteName -> { runDir, report, generatedAtUtc }
 $newestPerSuite = @{}
 
-foreach ($machine in $machines) {
-    Write-Host "Scanning: $($machine.Name)" -ForegroundColor Cyan
-
-    # Walk all date/time dirs
-    $dateDirs = Get-ChildItem $machine.FullName -Directory | Sort-Object Name -Descending
-
-    foreach ($dateDir in $dateDirs) {
-        $timeDirs = Get-ChildItem $dateDir.FullName -Directory | Sort-Object Name -Descending
-
-        foreach ($timeDir in $timeDirs) {
-            $reportPath = Join-Path $timeDir.FullName 'report.json'
-            if (-not (Test-Path $reportPath)) { continue }
+foreach ($reportFile in @(Get-ChildItem $BenchDir -Recurse -File -Filter 'report.json' | Sort-Object LastWriteTimeUtc -Descending)) {
+            $reportPath = $reportFile.FullName
 
             try {
                 $report = Get-Content $reportPath -Raw | ConvertFrom-Json
@@ -142,22 +138,28 @@ foreach ($machine in $machines) {
 
             if ($report.totalBenchmarkCount -le 0) { continue }
 
+            $machineName = if ($report.provenance -and $report.provenance.machineName) {
+                $report.provenance.machineName
+            } else {
+                'unknown'
+            }
+
             foreach ($suite in $report.suites) {
                 $name = $suite.suiteName
 
                 # Keep the newest run for this suite
                 if (-not $newestPerSuite.ContainsKey($name)) {
                     $newestPerSuite[$name] = @{
-                        RunDir          = $timeDir.FullName
+                        RunDir          = $reportFile.DirectoryName
                         Report          = $report
                         GeneratedAtUtc  = $report.generatedAtUtc
-                        Machine         = $machine.Name
+                        Machine         = $machineName
                     }
                 }
             }
-        }
-    }
 }
+
+$machines = @($newestPerSuite.Values | ForEach-Object { $_.Machine } | Sort-Object -Unique)
 
 if ($newestPerSuite.Count -eq 0) {
     Write-Warning "No suites found in any run."
@@ -167,8 +169,6 @@ if ($newestPerSuite.Count -eq 0) {
 Write-Host "Found $($newestPerSuite.Count) suites across all runs." -ForegroundColor Green
 
 # ── Generate pages ────────────────────────────────────────────────────────────
-
-New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
 
 # Remove old generated files (keep any hand-written content, but since these
 # are all auto-generated, safe to clear *.md and *.json that match our suites)
@@ -265,6 +265,41 @@ foreach ($entry in $sortedSuites) {
     Write-Host "  $fileName" -ForegroundColor Green
     $pageCount++
 
+}
+
+# Rowles.Text and compression use their own BenchmarkDotNet executables. Surface
+# their newest output without forcing them through the Core report schema.
+$latestRunDirectories = @(Get-ChildItem $BenchDir -Directory | Sort-Object LastWriteTimeUtc -Descending)
+foreach ($projectKey in @('text', 'compression')) {
+    $projectDirectory = $null
+    foreach ($runDirectory in $latestRunDirectories) {
+        $candidate = Join-Path $runDirectory.FullName $projectKey
+        if ((Test-Path $candidate) -and @(Get-ChildItem $candidate -Recurse -File -Filter '*-report-github.md' -ErrorAction SilentlyContinue).Count -gt 0) {
+            $projectDirectory = $candidate
+            break
+        }
+    }
+    if (-not $projectDirectory) { continue }
+
+    $title = if ($projectKey -eq 'text') { 'Rowles.Text benchmarks' } else { 'Compression benchmarks' }
+    $builder = [System.Text.StringBuilder]::new()
+    [void]$builder.AppendLine('---')
+    [void]$builder.AppendLine("title: $title")
+    [void]$builder.AppendLine('---')
+    [void]$builder.AppendLine()
+    [void]$builder.AppendLine("# $title")
+    [void]$builder.AppendLine()
+    foreach ($markdownFile in @(Get-ChildItem $projectDirectory -Recurse -File -Filter '*-report-github.md' | Sort-Object Name)) {
+        $table = Get-TableContent $markdownFile.FullName
+        if (-not $table) { continue }
+        [void]$builder.AppendLine("## $($markdownFile.BaseName -replace '-report-github$', '')")
+        [void]$builder.AppendLine()
+        [void]$builder.AppendLine($table)
+        [void]$builder.AppendLine()
+    }
+    $builder.ToString() | Set-Content (Join-Path $OutputDir "$projectKey.md") -Encoding UTF8
+    Write-Host "  $projectKey.md" -ForegroundColor Green
+    $pageCount++
 }
 
 # ── benchmark-charts.js ───────────────────────────────────────────────────────

--- a/scripts/benchmarks/generate-docs.ps1
+++ b/scripts/benchmarks/generate-docs.ps1
@@ -136,6 +136,13 @@ foreach ($reportFile in @(Get-ChildItem $BenchDir -Recurse -File -Filter 'report
                 continue
             }
 
+            $reportProperties = @($report.PSObject.Properties | ForEach-Object { $_.Name })
+            if ('totalBenchmarkCount' -notin $reportProperties -or
+                'suites' -notin $reportProperties -or
+                'generatedAtUtc' -notin $reportProperties) {
+                continue
+            }
+
             if ($report.totalBenchmarkCount -le 0) { continue }
 
             $machineName = if ($report.provenance -and $report.provenance.machineName) {

--- a/scripts/benchmarks/generate-docs.ps1
+++ b/scripts/benchmarks/generate-docs.ps1
@@ -20,7 +20,8 @@
 #>
 param(
     [string]$BenchDir  = '',
-    [string]$OutputDir = ''
+    [string]$OutputDir = '',
+    [string]$PublishedDir = ''
 )
 
 Set-StrictMode -Version Latest
@@ -30,15 +31,19 @@ $repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
 
 if ([string]::IsNullOrEmpty($BenchDir))  { $BenchDir  = Join-Path $repoRoot 'artifacts/benchmark/runs' }
 if ([string]::IsNullOrEmpty($OutputDir)) { $OutputDir = Join-Path $repoRoot 'artifacts\docs\generated\benchmarks' }
+if ([string]::IsNullOrEmpty($PublishedDir)) { $PublishedDir = Join-Path $repoRoot 'docs/benchmarks' }
 
 $BenchDir  = [System.IO.Path]::GetFullPath($BenchDir)
 $OutputDir = [System.IO.Path]::GetFullPath($OutputDir)
+$PublishedDir = [System.IO.Path]::GetFullPath($PublishedDir)
 
 # Preserve the last published benchmark documentation until a newer run exists.
 # This keeps a clean checkout buildable while moving generated output out of docs/.
 [void][System.IO.Directory]::CreateDirectory($OutputDir)
-$publishedDirectory = Join-Path $repoRoot 'docs/benchmarks'
-foreach ($publishedFile in @(Get-ChildItem $publishedDirectory -File -ErrorAction SilentlyContinue)) {
+foreach ($stagedItem in @(Get-ChildItem $OutputDir -Force -ErrorAction SilentlyContinue)) {
+    Remove-Item -LiteralPath $stagedItem.FullName -Recurse -Force
+}
+foreach ($publishedFile in @(Get-ChildItem $PublishedDir -File -ErrorAction SilentlyContinue)) {
     Copy-Item -LiteralPath $publishedFile.FullName -Destination (Join-Path $OutputDir $publishedFile.Name) -Force
 }
 
@@ -116,79 +121,131 @@ function Get-TableContent([string]$path) {
     return $null
 }
 
-# ── Collect runs ──────────────────────────────────────────────────────────────
-
-if (-not (Test-Path $BenchDir)) {
-    Write-Warning "No benchmark runs found in $BenchDir"
-    exit 0
+# Collect runs.
+function Read-JsonDocument([string]$Path) {
+    try {
+        return Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+    } catch {
+        Write-Warning "  Failed to parse $Path, skipping."
+        return $null
+    }
 }
 
-# Map: suiteName -> { runDir, report, generatedAtUtc }
+function Get-DocumentProperty($Document, [string]$Name, $Default = $null) {
+    if ($null -eq $Document) { return $Default }
+    $property = $Document.PSObject.Properties[$Name]
+    if ($null -eq $property) { return $Default }
+    return $property.Value
+}
+
+function Test-CoreReportShape($Report) {
+    $names = @($Report.PSObject.Properties.Name)
+    return 'totalBenchmarkCount' -in $names -and 'suites' -in $names -and 'generatedAtUtc' -in $names
+}
+
 $newestPerSuite = @{}
+$newestProjectEvidence = @{}
+$runDirectories = if (Test-Path $BenchDir) { @(Get-ChildItem $BenchDir -Directory) } else { @() }
+if ($runDirectories.Count -eq 0) {
+    Write-Warning "No benchmark runs found in $BenchDir"
+}
 
-foreach ($reportFile in @(Get-ChildItem $BenchDir -Recurse -File -Filter 'report.json' | Sort-Object LastWriteTimeUtc -Descending)) {
-            $reportPath = $reportFile.FullName
+foreach ($runDirectory in $runDirectories) {
+    $runReportPath = Join-Path $runDirectory.FullName 'run-report.json'
+    if (-not (Test-Path $runReportPath -PathType Leaf)) { continue }
 
-            try {
-                $report = Get-Content $reportPath -Raw | ConvertFrom-Json
-            } catch {
-                Write-Warning "  Failed to parse $reportPath, skipping."
-                continue
-            }
+    $runManifestPath = Join-Path $runDirectory.FullName 'run.json'
+    if (-not (Test-Path $runManifestPath -PathType Leaf)) { continue }
+    $runManifest = Read-JsonDocument $runManifestPath
+    $runReport = Read-JsonDocument $runReportPath
+    if ($null -eq $runManifest -or $null -eq $runReport) { continue }
 
-            $reportProperties = @($report.PSObject.Properties | ForEach-Object { $_.Name })
-            if ('totalBenchmarkCount' -notin $reportProperties -or
-                'suites' -notin $reportProperties -or
-                'generatedAtUtc' -notin $reportProperties) {
-                continue
-            }
+    try {
+        $completedAtUtc = [DateTimeOffset]::Parse([string](Get-DocumentProperty $runManifest 'completedAtUtc'))
+    } catch {
+        Write-Warning "  Invalid completion timestamp in $runManifestPath, skipping."
+        continue
+    }
 
-            if ($report.totalBenchmarkCount -le 0) { continue }
+    $projects = @(Get-DocumentProperty $runReport 'projects' @())
+    foreach ($projectKey in @('core', 'text', 'compression')) {
+        $project = @($projects | Where-Object {
+            (Get-DocumentProperty $_ 'project' '') -ceq $projectKey
+        } | Select-Object -First 1)
+        if ($project.Count -eq 0 -or (Get-DocumentProperty $project[0] 'status' '') -cne 'Passed') { continue }
 
-            $machineName = if ($report.provenance -and $report.provenance.machineName) {
-                $report.provenance.machineName
-            } else {
-                'unknown'
-            }
+        $relativeProjectPath = [string](Get-DocumentProperty $project[0] 'path' $projectKey)
+        $projectDirectory = Join-Path $runDirectory.FullName $relativeProjectPath
+        if (-not (Test-Path $projectDirectory -PathType Container)) { continue }
 
-            foreach ($suite in $report.suites) {
-                $name = $suite.suiteName
+        if ($projectKey -eq 'core') {
+            $reportPath = Join-Path $projectDirectory 'report.json'
+            if (-not (Test-Path $reportPath -PathType Leaf)) { continue }
+            $report = Read-JsonDocument $reportPath
+            if ($null -eq $report -or -not (Test-CoreReportShape $report) -or [long]$report.totalBenchmarkCount -le 0) { continue }
 
-                # Keep the newest run for this suite
-                if (-not $newestPerSuite.ContainsKey($name)) {
+            $machineName = [string](Get-DocumentProperty (Get-DocumentProperty $report 'provenance') 'machineName' 'unknown')
+            foreach ($suite in @($report.suites)) {
+                $name = [string](Get-DocumentProperty $suite 'suiteName' '')
+                if (-not $name) { continue }
+                if ([long](Get-DocumentProperty $suite 'failedBenchmarkCount' 0) -gt 0 -or
+                    [long](Get-DocumentProperty $suite 'missingBenchmarkCount' 0) -gt 0) { continue }
+                if (-not $newestPerSuite.ContainsKey($name) -or $completedAtUtc -gt $newestPerSuite[$name].CompletedAtUtc) {
                     $newestPerSuite[$name] = @{
-                        RunDir          = $reportFile.DirectoryName
-                        Report          = $report
-                        GeneratedAtUtc  = $report.generatedAtUtc
-                        Machine         = $machineName
+                        RunDir = $projectDirectory
+                        Report = $report
+                        CompletedAtUtc = $completedAtUtc
+                        Machine = $machineName
                     }
                 }
             }
+            continue
+        }
+
+        $markdownFiles = @(Get-ChildItem $projectDirectory -Recurse -File -Filter '*-report-github.md' -ErrorAction SilentlyContinue |
+            Where-Object { -not [string]::IsNullOrWhiteSpace((Get-TableContent $_.FullName)) })
+        if ($markdownFiles.Count -eq 0) { continue }
+        if (-not $newestProjectEvidence.ContainsKey($projectKey) -or
+            $completedAtUtc -gt $newestProjectEvidence[$projectKey].CompletedAtUtc) {
+            $newestProjectEvidence[$projectKey] = @{
+                Directory = $projectDirectory
+                CompletedAtUtc = $completedAtUtc
+            }
+        }
+    }
+}
+
+# Legacy Core reports remain supported only for runs without run-report.json.
+foreach ($runDirectory in @($runDirectories | Where-Object { -not (Test-Path (Join-Path $_.FullName 'run-report.json')) })) {
+    foreach ($reportFile in @(Get-ChildItem $runDirectory.FullName -Recurse -File -Filter 'report.json' -ErrorAction SilentlyContinue)) {
+        $report = Read-JsonDocument $reportFile.FullName
+        if ($null -eq $report -or -not (Test-CoreReportShape $report) -or [long]$report.totalBenchmarkCount -le 0) { continue }
+        try { $generatedAtUtc = [DateTimeOffset]::Parse([string]$report.generatedAtUtc) } catch { continue }
+        $machineName = [string](Get-DocumentProperty (Get-DocumentProperty $report 'provenance') 'machineName' 'unknown')
+        foreach ($suite in @($report.suites)) {
+            $name = [string](Get-DocumentProperty $suite 'suiteName' '')
+            if (-not $name) { continue }
+            if (-not $newestPerSuite.ContainsKey($name) -or $generatedAtUtc -gt $newestPerSuite[$name].CompletedAtUtc) {
+                $newestPerSuite[$name] = @{
+                    RunDir = $reportFile.DirectoryName
+                    Report = $report
+                    CompletedAtUtc = $generatedAtUtc
+                    Machine = $machineName
+                }
+            }
+        }
+    }
 }
 
 $machines = @($newestPerSuite.Values | ForEach-Object { $_.Machine } | Sort-Object -Unique)
-
 if ($newestPerSuite.Count -eq 0) {
-    Write-Warning "No suites found in any run."
-    exit 0
+    Write-Warning 'No valid Core benchmark suites found; preserving the published Core pages.'
+} else {
+    Write-Host "Found $($newestPerSuite.Count) Core suites across all runs." -ForegroundColor Green
 }
 
-Write-Host "Found $($newestPerSuite.Count) suites across all runs." -ForegroundColor Green
-
-# ── Generate pages ────────────────────────────────────────────────────────────
-
-# Remove old generated files (keep any hand-written content, but since these
-# are all auto-generated, safe to clear *.md and *.json that match our suites)
-$existingMd = Get-ChildItem $OutputDir -Filter '*.md' -ErrorAction SilentlyContinue
-foreach ($f in $existingMd) {
-    Remove-Item $f.FullName -Force
-}
-$existingJson = Get-ChildItem $OutputDir -Filter '*.json' -ErrorAction SilentlyContinue
-foreach ($f in $existingJson) {
-    Remove-Item $f.FullName -Force
-}
-
-$pageCount   = 0
+# Generate pages.
+$pageCount = 0
 
 # Sort suites by display name for a stable TOC order
 $sortedSuites = $newestPerSuite.GetEnumerator() |
@@ -241,6 +298,8 @@ foreach ($entry in $sortedSuites) {
     if ($jsonFiles.Count -gt 0) {
         Copy-Item $jsonFiles[0].FullName $jsonOutPath -Force
         $hasCharts = $true
+    } elseif (Test-Path $jsonOutPath) {
+        Remove-Item -LiteralPath $jsonOutPath -Force
     }
 
     $chartId = $suiteName -replace '[^a-zA-Z0-9]', '-'
@@ -274,19 +333,10 @@ foreach ($entry in $sortedSuites) {
 
 }
 
-# Rowles.Text and compression use their own BenchmarkDotNet executables. Surface
-# their newest output without forcing them through the Core report schema.
-$latestRunDirectories = @(Get-ChildItem $BenchDir -Directory | Sort-Object LastWriteTimeUtc -Descending)
+# Rowles.Text and compression use their own BenchmarkDotNet executables.
 foreach ($projectKey in @('text', 'compression')) {
-    $projectDirectory = $null
-    foreach ($runDirectory in $latestRunDirectories) {
-        $candidate = Join-Path $runDirectory.FullName $projectKey
-        if ((Test-Path $candidate) -and @(Get-ChildItem $candidate -Recurse -File -Filter '*-report-github.md' -ErrorAction SilentlyContinue).Count -gt 0) {
-            $projectDirectory = $candidate
-            break
-        }
-    }
-    if (-not $projectDirectory) { continue }
+    if (-not $newestProjectEvidence.ContainsKey($projectKey)) { continue }
+    $projectDirectory = $newestProjectEvidence[$projectKey].Directory
 
     $title = if ($projectKey -eq 'text') { 'Rowles.Text benchmarks' } else { 'Compression benchmarks' }
     $builder = [System.Text.StringBuilder]::new()

--- a/scripts/data/download-gutenberg.ps1
+++ b/scripts/data/download-gutenberg.ps1
@@ -4,7 +4,7 @@
 
 .DESCRIPTION
     Downloads a curated set of public-domain books from Project Gutenberg
-    into bench/data/gutenberg-ebooks/. Files are named by Gutenberg ID (e.g. 84.txt).
+    into artifacts/benchmark/cache/data/gutenberg-ebooks/. Files are named by Gutenberg ID (e.g. 84.txt).
 
     When BookCount exceeds the curated seed list, the script downloads the
     Gutenberg catalogue CSV, caches it locally, and supplements from the
@@ -19,7 +19,7 @@
     When BookCount > seed list size, the catalogue is consulted for the remainder.
 
 .PARAMETER OutputDir
-    Override the output directory. Defaults to bench/data/gutenberg-ebooks relative
+    Override the output directory. Defaults to artifacts/benchmark/cache/data/gutenberg-ebooks relative
     to the repository root.
 
 .EXAMPLE
@@ -47,12 +47,14 @@ if ($BookCount -lt 1) {
 }
 
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+. (Join-Path $repoRoot 'scripts/devops/artifacts/paths.ps1')
+$dataRoot = Get-BenchmarkDataRoot -RepoRoot $repoRoot
 
 if ([string]::IsNullOrEmpty($OutputDir)) {
-    $OutputDir = Join-Path $repoRoot "bench\data\gutenberg-ebooks"
+    $OutputDir = Join-Path $dataRoot 'gutenberg-ebooks'
 }
 
-$catalogCacheDir  = Join-Path $repoRoot "bench\data"
+$catalogCacheDir  = $dataRoot
 $catalogCachePath = Join-Path $catalogCacheDir ".gutenberg-catalog.csv"
 
 New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null

--- a/scripts/data/download-news.ps1
+++ b/scripts/data/download-news.ps1
@@ -19,7 +19,7 @@
     Both datasets are free for research and academic use.
 
 .PARAMETER OutputDir
-    Override the base output directory. Defaults to bench/data relative to the
+    Override the base output directory. Defaults to artifacts/benchmark/cache/data relative to the
     repository root. Datasets are extracted into subdirectories within it.
 
 .PARAMETER Skip20News
@@ -43,9 +43,10 @@ param(
 )
 
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+. (Join-Path $repoRoot 'scripts/devops/artifacts/paths.ps1')
 
 if ([string]::IsNullOrEmpty($OutputDir)) {
-    $OutputDir = Join-Path $repoRoot "bench\data"
+    $OutputDir = Get-BenchmarkDataRoot -RepoRoot $repoRoot
 }
 
 New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null

--- a/scripts/data/download-wikipedia.ps1
+++ b/scripts/data/download-wikipedia.ps1
@@ -5,7 +5,7 @@
 .DESCRIPTION
     Uses the Wikipedia MediaWiki API to download the introductory text of randomly
     selected Wikipedia articles as plain-text .txt files in
-    bench/data/wikipedia/{language}/. Each article is written to its own file,
+    artifacts/benchmark/cache/data/wikipedia/{language}/. Each article is written to its own file,
     named with a random GUID (e.g. 7a3b2c1d-...txt).
 
     Specify a BCP 47 language code (e.g. en, fr, de, zh, ja) to target that
@@ -24,7 +24,7 @@
     to download from (e.g. "fr" for fr.wikipedia.org).
 
 .PARAMETER OutputDir
-    Override the output directory. Defaults to bench/data/wikipedia/{language} relative
+    Override the output directory. Defaults to artifacts/benchmark/cache/data/wikipedia/{language} relative
     to the repository root.
 
 .PARAMETER ArticleCount
@@ -49,9 +49,10 @@ param(
 )
 
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+. (Join-Path $repoRoot 'scripts/devops/artifacts/paths.ps1')
 
 if ([string]::IsNullOrEmpty($OutputDir)) {
-    $OutputDir = Join-Path $repoRoot "bench\data\wikipedia\$Language"
+    $OutputDir = Join-Path (Get-BenchmarkDataRoot -RepoRoot $repoRoot) "wikipedia/$Language"
 }
 
 New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null

--- a/scripts/devops/DevOps.psm1
+++ b/scripts/devops/DevOps.psm1
@@ -6,6 +6,10 @@ Set-StrictMode -Version Latest
 . "$PSScriptRoot/common/arguments.ps1"
 . "$PSScriptRoot/common/processes.ps1"
 . "$PSScriptRoot/common/tools.ps1"
+. "$PSScriptRoot/artifacts/paths.ps1"
+. "$PSScriptRoot/artifacts/manifests.ps1"
+. "$PSScriptRoot/artifacts/runs.ps1"
+. "$PSScriptRoot/artifacts/clean.ps1"
 
 $Script:TestSuites = Import-PowerShellDataFile "$PSScriptRoot/config/test-suites.psd1"
 $Script:BenchmarkSuites = Import-PowerShellDataFile "$PSScriptRoot/config/benchmark-suites.psd1"
@@ -38,6 +42,8 @@ $Script:BenchmarkStrategies = Import-PowerShellDataFile "$PSScriptRoot/config/be
 . "$PSScriptRoot/commands/setup.ps1"
 . "$PSScriptRoot/commands/report.ps1"
 . "$PSScriptRoot/commands/server.ps1"
+. "$PSScriptRoot/commands/clean.ps1"
+. "$PSScriptRoot/commands/pack.ps1"
 
 function Invoke-DevOps {
     param([string]$Command, [string[]]$Arguments)
@@ -55,6 +61,8 @@ function Invoke-DevOps {
         'setup'      { Invoke-DevOpsSetup -Arguments $Arguments }
         'report'     { Invoke-DevOpsReport -Arguments $Arguments }
         'server'     { Invoke-DevOpsServer -Arguments $Arguments }
+        'clean'      { Invoke-DevOpsClean -Arguments $Arguments }
+        'pack'       { Invoke-DevOpsPack -Arguments $Arguments }
         ''           { Invoke-DevOpsHelp }
         '--help'     { Invoke-DevOpsHelp }
         '-Help'      { Invoke-DevOpsHelp }
@@ -92,6 +100,10 @@ function Invoke-DevOpsHelp {
     Write-Host '      -Diagnostics        Enable MTP diagnostic logging and artefact capture'
     Write-Host '      -CI                 Use CI-prepared managed output and write run artefacts'
     Write-Host '      -CollectCoverage    Collect coverage for registry-eligible suites'
+    Write-Host '      -Profile            unit, integration, or stress parallel execution profile'
+    Write-Host '      -Explicit           Include explicit tests'
+    Write-Host '      -ExplicitOnly       Run only explicit tests'
+    Write-Host '      -FailWarnings       Treat xUnit warnings as failures'
     Write-Host '      -Timeout            Outer process timeout, for example 30s or off'
     Write-Host '      -List               List available suites and exit'
     Write-Host ''
@@ -110,8 +122,8 @@ function Invoke-DevOpsHelp {
     Write-Host '    diagnostics          Attach standard .NET diagnostics to a process'
     Write-Host '      ps                  List process IDs and names'
     Write-Host '      counters --pid ID  Monitor counters; use -- for tool arguments'
-    Write-Host '      trace --pid ID     Capture a trace under artifacts/diagnostics'
-    Write-Host '      gcdump --pid ID    Capture a GC dump under artifacts/diagnostics'
+    Write-Host '      trace --pid ID     Capture a trace under artifacts/diagnostics/runs'
+    Write-Host '      gcdump --pid ID    Capture a GC dump under artifacts/diagnostics/runs'
     Write-Host '      dump --pid ID      Capture a dump (default type: Mini)'
     Write-Host '      symbols ARTIFACT   Download symbols for an explicit artifact'
     Write-Host '      capture --pid ID   Capture bounded counters and trace data'
@@ -157,6 +169,8 @@ function Invoke-DevOpsHelp {
     Write-Host ''
 
     Write-Host '    setup                Verify dev environment and directories'
+    Write-Host '    clean [target]       Remove owned artefacts; default preserves packages and benchmark data/runs'
+    Write-Host '    pack                 Build NuGet packages under artifacts/package/release'
     Write-Host '    report               Repository health report'
     Write-Host '      git                 Repository/commit-level stats (default: all groups)'
     Write-Host '      files               Per-file facts and history'

--- a/scripts/devops/artifacts/clean.ps1
+++ b/scripts/devops/artifacts/clean.ps1
@@ -1,0 +1,48 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Remove-OwnedArtifactPath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+        [Parameter(Mandatory = $true)]
+        [string]$ArtifactRoot
+    )
+    $root = [System.IO.Path]::GetFullPath($ArtifactRoot).TrimEnd([System.IO.Path]::DirectorySeparatorChar)
+    $resolved = [System.IO.Path]::GetFullPath($Path)
+    if (-not $resolved.StartsWith($root + [System.IO.Path]::DirectorySeparatorChar, [StringComparison]::OrdinalIgnoreCase) -and
+        -not [string]::Equals($resolved, $root, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Refusing to clean path outside the artefact root: $resolved"
+    }
+    if (Test-Path $resolved) {
+        Remove-Item -LiteralPath $resolved -Recurse -Force
+        Write-Info "  removed $([System.IO.Path]::GetRelativePath((Get-RepoRoot), $resolved))"
+    }
+}
+
+function Invoke-ArtifactClean {
+    param(
+        [string]$Target = 'default',
+        [string]$RepoRoot = (Get-RepoRoot)
+    )
+    $root = Get-ArtifactRoot -RepoRoot $RepoRoot
+    $map = @{
+        test = @('test')
+        coverage = @('coverage')
+        docs = @('docs')
+        diagnostics = @('diagnostics')
+        benchmark = @('benchmark/runs')
+        package = @('package')
+        cache = @('benchmark/cache')
+        default = @('bin', 'obj', 'publish', 'test', 'coverage', 'diagnostics', 'docs', 'temp')
+        all = @('')
+    }
+    $key = $Target.ToLowerInvariant()
+    if (-not $map.ContainsKey($key)) {
+        throw "Unknown clean target '$Target'. Valid: default, test, coverage, docs, diagnostics, benchmark, package, cache, all."
+    }
+    foreach ($relative in @($map[$key])) {
+        $path = if ($relative) { Join-Path $root $relative } else { $root }
+        Remove-OwnedArtifactPath -Path $path -ArtifactRoot $root
+    }
+}

--- a/scripts/devops/artifacts/clean.ps1
+++ b/scripts/devops/artifacts/clean.ps1
@@ -10,8 +10,9 @@ function Remove-OwnedArtifactPath {
     )
     $root = [System.IO.Path]::GetFullPath($ArtifactRoot).TrimEnd([System.IO.Path]::DirectorySeparatorChar)
     $resolved = [System.IO.Path]::GetFullPath($Path)
-    if (-not $resolved.StartsWith($root + [System.IO.Path]::DirectorySeparatorChar, [StringComparison]::OrdinalIgnoreCase) -and
-        -not [string]::Equals($resolved, $root, [StringComparison]::OrdinalIgnoreCase)) {
+    $comparison = if ($IsWindows) { [StringComparison]::OrdinalIgnoreCase } else { [StringComparison]::Ordinal }
+    if (-not $resolved.StartsWith($root + [System.IO.Path]::DirectorySeparatorChar, $comparison) -and
+        -not [string]::Equals($resolved, $root, $comparison)) {
         throw "Refusing to clean path outside the artefact root: $resolved"
     }
     if (Test-Path $resolved) {

--- a/scripts/devops/artifacts/manifests.ps1
+++ b/scripts/devops/artifacts/manifests.ps1
@@ -1,0 +1,63 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function ConvertTo-ArtifactJson {
+    param([object]$Value)
+    return ($Value | ConvertTo-Json -Depth 30)
+}
+
+function Write-AtomicTextFile {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$Content
+    )
+
+    $parent = Split-Path -Parent $Path
+    if ($parent) {
+        [void][System.IO.Directory]::CreateDirectory($parent)
+    }
+
+    $temporaryPath = "$Path.$([Guid]::NewGuid().ToString('N')).tmp"
+    try {
+        [System.IO.File]::WriteAllText($temporaryPath, $Content, [System.Text.UTF8Encoding]::new($false))
+        [System.IO.File]::Move($temporaryPath, $Path, $true)
+    } catch {
+        if ([System.IO.File]::Exists($temporaryPath)) {
+            [System.IO.File]::Delete($temporaryPath)
+        }
+        throw
+    }
+}
+
+function Write-AtomicJsonFile {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+        [Parameter(Mandatory = $true)]
+        [object]$Value
+    )
+    Write-AtomicTextFile -Path $Path -Content (ConvertTo-ArtifactJson $Value)
+}
+
+function Update-ArtifactRunManifest {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RunDirectory,
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Values
+    )
+
+    $path = Join-Path $RunDirectory 'run.json'
+    if (-not (Test-Path $path -PathType Leaf)) {
+        throw "Run manifest not found: $path"
+    }
+
+    $manifest = Get-Content -Raw $path | ConvertFrom-Json -AsHashtable
+    foreach ($key in $Values.Keys) {
+        $manifest[$key] = $Values[$key]
+    }
+    Write-AtomicJsonFile -Path $path -Value $manifest
+}

--- a/scripts/devops/artifacts/paths.ps1
+++ b/scripts/devops/artifacts/paths.ps1
@@ -1,0 +1,41 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Get-ArtifactRoot {
+    param([string]$RepoRoot = (Get-RepoRoot))
+    return Join-Path $RepoRoot 'artifacts'
+}
+
+function Get-ArtifactKindRoot {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('test', 'coverage', 'benchmark', 'diagnostics', 'docs', 'package', 'temp')]
+        [string]$Kind,
+        [string]$RepoRoot = (Get-RepoRoot)
+    )
+    return Join-Path (Get-ArtifactRoot -RepoRoot $RepoRoot) $Kind
+}
+
+function Get-ArtifactRunsRoot {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('test', 'coverage', 'benchmark', 'diagnostics')]
+        [string]$Kind,
+        [string]$RepoRoot = (Get-RepoRoot)
+    )
+    return Join-Path (Get-ArtifactKindRoot -Kind $Kind -RepoRoot $RepoRoot) 'runs'
+}
+
+function Get-BenchmarkDataRoot {
+    param([string]$RepoRoot = (Get-RepoRoot))
+    return Join-Path (Get-ArtifactKindRoot -Kind benchmark -RepoRoot $RepoRoot) 'cache/data'
+}
+
+function Get-DocsArtifactPath {
+    param(
+        [ValidateSet('api', 'coverage', 'site', 'diagnostics', 'generated')]
+        [string]$Name,
+        [string]$RepoRoot = (Get-RepoRoot)
+    )
+    return Join-Path (Get-ArtifactKindRoot -Kind docs -RepoRoot $RepoRoot) $Name
+}

--- a/scripts/devops/artifacts/runs.ps1
+++ b/scripts/devops/artifacts/runs.ps1
@@ -1,0 +1,119 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function New-ArtifactRunId {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('test', 'coverage', 'benchmark', 'diagnostics')]
+        [string]$Kind,
+        [string]$Framework = ''
+    )
+
+    $utc = [DateTime]::UtcNow
+    $entropy = [Guid]::NewGuid().ToString('N').Substring(0, 8)
+    $os = if ($IsWindows) { 'windows' } elseif ($IsMacOS) { 'macos' } else { 'linux' }
+    $suffix = if ($Framework) { "-$os-$($Framework.Replace('.', ''))" } else { "-$os" }
+    return "$($utc.ToString('yyyyMMdd-HHmmss'))-$entropy$suffix"
+}
+
+function Get-ArtifactGitContext {
+    param([string]$RepoRoot = (Get-RepoRoot))
+
+    $commit = (& git -C $RepoRoot rev-parse HEAD 2>$null | Select-Object -First 1) -as [string]
+    $branch = (& git -C $RepoRoot rev-parse --abbrev-ref HEAD 2>$null | Select-Object -First 1) -as [string]
+    return [ordered]@{
+        commit = if ($commit) { $commit.Trim() } else { '' }
+        branch = if ($branch) { $branch.Trim() } else { '' }
+        dirty = @(& git -C $RepoRoot status --porcelain --untracked-files=all 2>$null).Count -gt 0
+    }
+}
+
+function New-ArtifactRun {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('test', 'coverage', 'benchmark', 'diagnostics')]
+        [string]$Kind,
+        [string]$Framework = '',
+        [string]$Configuration = 'Release',
+        [string]$Target = '',
+        [string]$CommandLine = '',
+        [string]$RepoRoot = (Get-RepoRoot),
+        [string]$RunId = ''
+    )
+
+    if (-not $RunId) {
+        $RunId = New-ArtifactRunId -Kind $Kind -Framework $Framework
+    }
+    $runDirectory = Join-Path (Get-ArtifactRunsRoot -Kind $Kind -RepoRoot $RepoRoot) $RunId
+    [void][System.IO.Directory]::CreateDirectory($runDirectory)
+    $git = Get-ArtifactGitContext -RepoRoot $RepoRoot
+    $manifest = [ordered]@{
+        schemaVersion = 1
+        runId = $RunId
+        kind = $Kind
+        startedAtUtc = [DateTime]::UtcNow.ToString('O')
+        completedAtUtc = $null
+        commit = $git.commit
+        branch = $git.branch
+        dirty = $git.dirty
+        framework = $Framework
+        configuration = $Configuration
+        os = [System.Runtime.InteropServices.RuntimeInformation]::OSDescription
+        architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()
+        machine = [Environment]::MachineName
+        ci = [bool]([Environment]::GetEnvironmentVariable('CI'))
+        target = $Target
+        commandLine = $CommandLine
+        status = 'Running'
+    }
+    Write-AtomicJsonFile -Path (Join-Path $runDirectory 'run.json') -Value $manifest
+    return [pscustomobject]@{ RunId = $RunId; RunDirectory = $runDirectory; Manifest = $manifest }
+}
+
+function Complete-ArtifactRun {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RunDirectory,
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Passed', 'Failed', 'Incomplete', 'Cancelled')]
+        [string]$Status,
+        [hashtable]$AdditionalValues = @{}
+    )
+    $values = @{
+        completedAtUtc = [DateTime]::UtcNow.ToString('O')
+        status = $Status
+    }
+    foreach ($key in $AdditionalValues.Keys) { $values[$key] = $AdditionalValues[$key] }
+    Update-ArtifactRunManifest -RunDirectory $RunDirectory -Values $values
+}
+
+function Set-ArtifactProcessEnvironment {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RunId,
+        [Parameter(Mandatory = $true)]
+        [string]$Kind,
+        [Parameter(Mandatory = $true)]
+        [string]$ArtifactDirectory,
+        [string]$Target = '',
+        [int]$Iteration = 1,
+        [bool]$Ci = $false,
+        [bool]$Diagnostics = $false
+    )
+    $env:LEANCORPUS_RUN_ID = $RunId
+    $env:LEANCORPUS_RUN_KIND = $Kind
+    $env:LEANCORPUS_ARTIFACT_DIR = $ArtifactDirectory
+    $env:LEANCORPUS_TARGET = $Target
+    $env:LEANCORPUS_ITERATION = $Iteration.ToString([Globalization.CultureInfo]::InvariantCulture)
+    $env:LEANCORPUS_CI = $Ci.ToString().ToLowerInvariant()
+    $env:LEANCORPUS_DIAGNOSTICS = $Diagnostics.ToString().ToLowerInvariant()
+}
+
+function Clear-ArtifactProcessEnvironment {
+    foreach ($name in @(
+        'LEANCORPUS_RUN_ID', 'LEANCORPUS_RUN_KIND', 'LEANCORPUS_ARTIFACT_DIR',
+        'LEANCORPUS_TARGET', 'LEANCORPUS_ITERATION', 'LEANCORPUS_CI',
+        'LEANCORPUS_DIAGNOSTICS', 'LEANCORPUS_TELEMETRY')) {
+        [Environment]::SetEnvironmentVariable($name, $null)
+    }
+}

--- a/scripts/devops/artifacts/runs.ps1
+++ b/scripts/devops/artifacts/runs.ps1
@@ -96,6 +96,7 @@ function Set-ArtifactProcessEnvironment {
         [Parameter(Mandatory = $true)]
         [string]$ArtifactDirectory,
         [string]$Target = '',
+        [string]$Suite = '',
         [int]$Iteration = 1,
         [bool]$Ci = $false,
         [bool]$Diagnostics = $false
@@ -104,6 +105,7 @@ function Set-ArtifactProcessEnvironment {
     $env:LEANCORPUS_RUN_KIND = $Kind
     $env:LEANCORPUS_ARTIFACT_DIR = $ArtifactDirectory
     $env:LEANCORPUS_TARGET = $Target
+    $env:LEANCORPUS_SUITE = $Suite
     $env:LEANCORPUS_ITERATION = $Iteration.ToString([Globalization.CultureInfo]::InvariantCulture)
     $env:LEANCORPUS_CI = $Ci.ToString().ToLowerInvariant()
     $env:LEANCORPUS_DIAGNOSTICS = $Diagnostics.ToString().ToLowerInvariant()
@@ -112,7 +114,7 @@ function Set-ArtifactProcessEnvironment {
 function Clear-ArtifactProcessEnvironment {
     foreach ($name in @(
         'LEANCORPUS_RUN_ID', 'LEANCORPUS_RUN_KIND', 'LEANCORPUS_ARTIFACT_DIR',
-        'LEANCORPUS_TARGET', 'LEANCORPUS_ITERATION', 'LEANCORPUS_CI',
+        'LEANCORPUS_TARGET', 'LEANCORPUS_SUITE', 'LEANCORPUS_ITERATION', 'LEANCORPUS_CI',
         'LEANCORPUS_DIAGNOSTICS', 'LEANCORPUS_TELEMETRY')) {
         [Environment]::SetEnvironmentVariable($name, $null)
     }

--- a/scripts/devops/artifacts/runs.ps1
+++ b/scripts/devops/artifacts/runs.ps1
@@ -87,6 +87,64 @@ function Complete-ArtifactRun {
     Update-ArtifactRunManifest -RunDirectory $RunDirectory -Values $values
 }
 
+function Get-LatestSuccessfulArtifactRun {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('test', 'coverage', 'benchmark', 'diagnostics')]
+        [string]$Kind,
+        [string]$RepoRoot = (Get-RepoRoot),
+        [string]$Commit = ''
+    )
+
+    $runsRoot = Get-ArtifactRunsRoot -Kind $Kind -RepoRoot $RepoRoot
+    if (-not (Test-Path $runsRoot -PathType Container)) {
+        return $null
+    }
+
+    $candidates = [System.Collections.Generic.List[object]]::new()
+    foreach ($runDirectory in @(Get-ChildItem -LiteralPath $runsRoot -Directory -ErrorAction SilentlyContinue)) {
+        $manifestPath = Join-Path $runDirectory.FullName 'run.json'
+        if (-not (Test-Path $manifestPath -PathType Leaf)) {
+            continue
+        }
+
+        try {
+            $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+            if ([string]$manifest.status -ne 'Passed') {
+                continue
+            }
+            if ($Commit -and -not [string]::Equals(
+                    [string]$manifest.commit,
+                    $Commit,
+                    [StringComparison]::OrdinalIgnoreCase)) {
+                continue
+            }
+
+            $completedAtUtc = [DateTimeOffset]::MinValue
+            if (-not [DateTimeOffset]::TryParse(
+                    [string]$manifest.completedAtUtc,
+                    [Globalization.CultureInfo]::InvariantCulture,
+                    [Globalization.DateTimeStyles]::RoundtripKind,
+                    [ref]$completedAtUtc)) {
+                continue
+            }
+
+            [void]$candidates.Add([pscustomobject]@{
+                RunDirectory = $runDirectory.FullName
+                RunId = [string]$manifest.runId
+                Manifest = $manifest
+                CompletedAtUtc = $completedAtUtc
+            })
+        } catch {
+            # Retained runs can be incomplete or partially written. Ignore them
+            # during discovery and let the caller continue without evidence.
+            continue
+        }
+    }
+
+    return $candidates | Sort-Object CompletedAtUtc -Descending | Select-Object -First 1
+}
+
 function Set-ArtifactProcessEnvironment {
     param(
         [Parameter(Mandatory = $true)]

--- a/scripts/devops/commands/aot.ps1
+++ b/scripts/devops/commands/aot.ps1
@@ -46,6 +46,9 @@ function Invoke-DevOpsAot {
             Diagnostics = $diagnostics
             Ci = $ci
             CollectCoverage = $false
+            ExplicitMode = 'off'
+            ParallelProfile = 'integration'
+            FailWarnings = $false
             ArtifactsEnabled = $count -gt 1 -or $flaky -or $diagnostics -or $ci
             Configuration = $configuration
             RequestedFramework = if ($frameworkWasSpecified) { $framework } else { '' }

--- a/scripts/devops/commands/benchmark.ps1
+++ b/scripts/devops/commands/benchmark.ps1
@@ -36,7 +36,6 @@ function Invoke-DevOpsBenchmark {
     $list = $parsed.Has('List')
     $dry = $parsed.Has('Dry')
     $gcDump = $parsed.Has('GcDump')
-    $diagnostics = $parsed.Has('Diagnostics')
     $controlled = $parsed.Has('Controlled')
     $passThrough = $parsed.PassThrough
     $area = $parsed.Get('Area', '')
@@ -120,7 +119,6 @@ function Invoke-DevOpsBenchmark {
     if ($stratJobArgs)   { Write-Host "Job:        $($stratJobArgs -join ' ')" }
     if ($passThrough)    { Write-Host "BDN args:   $($passThrough -join ' ')" }
     Write-Host "Projects:   $($projectKeys -join ', ')"
-    if ($diagnostics)    { Write-Warn 'Diagnostic benchmark telemetry is non-comparable performance data.' }
 
     if ($dry) {
         Write-Host ''
@@ -145,6 +143,8 @@ function Invoke-DevOpsBenchmark {
     $benchmarkRun = New-ArtifactRun -Kind benchmark -Framework $framework -Configuration Release `
         -Target $suite -CommandLine $commandLine -RepoRoot $repoRoot
     $projectResults = [System.Collections.Generic.List[object]]::new()
+    $runCompleted = $false
+    $runFailure = $null
     try {
         foreach ($projectKey in $projectKeys) {
             $projectPath = Resolve-BenchmarkProjectPath $projectKey
@@ -156,8 +156,7 @@ function Invoke-DevOpsBenchmark {
             if ($gcDump -and $projectKey -eq 'core') { $runArgs += '--gcdump' }
 
             Set-ArtifactProcessEnvironment -RunId $benchmarkRun.RunId -Kind benchmark `
-                -ArtifactDirectory $projectDirectory -Target $projectKey -Diagnostics $diagnostics
-            $env:LEANCORPUS_TELEMETRY = if ($diagnostics) { 'full' } else { 'off' }
+                -ArtifactDirectory $projectDirectory -Target $projectKey
             Write-Info "Running benchmark project: $projectKey"
             dotnet run -c Release --framework $framework --project $projectPath -- @runArgs @stratJobArgs @passThrough
             $exitCode = $LASTEXITCODE
@@ -168,33 +167,56 @@ function Invoke-DevOpsBenchmark {
                 path = $projectKey
             })
         }
+        $failedProjects = @($projectResults | Where-Object { $_.status -ne 'Passed' })
+        $report = [ordered]@{
+            schemaVersion = 1
+            runId = $benchmarkRun.RunId
+            status = if ($failedProjects.Count -eq 0) { 'Passed' } else { 'Failed' }
+            framework = $framework
+            strategy = $strat
+            comparable = $true
+            projects = @($projectResults)
+        }
+        Write-AtomicJsonFile -Path (Join-Path $benchmarkRun.RunDirectory 'run-report.json') -Value $report
+        $markdown = @(
+            "# Benchmark run $($benchmarkRun.RunId)",
+            '',
+            "Status: $($report.status)",
+            '',
+            '| Project | Status | Path |',
+            '| --- | --- | --- |'
+        ) + @($projectResults | ForEach-Object { "| $($_.project) | $($_.status) | `$($_.path)/` |" })
+        Write-AtomicTextFile -Path (Join-Path $benchmarkRun.RunDirectory 'report.md') -Content ($markdown -join [Environment]::NewLine)
+        Complete-ArtifactRun -RunDirectory $benchmarkRun.RunDirectory -Status $report.status `
+            -AdditionalValues @{ projects = @($projectResults); report = 'run-report.json'; comparable = $true }
+        $runCompleted = $true
+    } catch {
+        $runFailure = $_.Exception
+        try {
+            Complete-ArtifactRun -RunDirectory $benchmarkRun.RunDirectory -Status Failed `
+                -AdditionalValues @{ error = $runFailure.Message }
+            $runCompleted = $true
+        } catch {
+            Write-Warn "Benchmark run could not be finalised as Failed: $($_.Exception.Message)"
+        }
+        Write-Failure "Benchmark command failed: $($runFailure.Message)"
     } finally {
         Clear-ArtifactProcessEnvironment
+        if (-not $runCompleted) {
+            try {
+                Complete-ArtifactRun -RunDirectory $benchmarkRun.RunDirectory -Status Incomplete `
+                    -AdditionalValues @{ error = 'Benchmark command did not complete normally.' }
+                $runCompleted = $true
+            } catch {
+                Write-Warn "Benchmark run remained unfinalised: $($_.Exception.Message)"
+            }
+        }
     }
 
-    $failedProjects = @($projectResults | Where-Object { $_.status -ne 'Passed' })
-    $report = [ordered]@{
-        schemaVersion = 1
-        runId = $benchmarkRun.RunId
-        status = if ($failedProjects.Count -eq 0) { 'Passed' } else { 'Failed' }
-        framework = $framework
-        strategy = $strat
-        diagnostics = $diagnostics
-        comparable = -not $diagnostics
-        projects = @($projectResults)
+    if ($null -ne $runFailure) {
+        exit 1
     }
-    Write-AtomicJsonFile -Path (Join-Path $benchmarkRun.RunDirectory 'report.json') -Value $report
-    $markdown = @(
-        "# Benchmark run $($benchmarkRun.RunId)",
-        '',
-        "Status: $($report.status)",
-        '',
-        '| Project | Status | Path |',
-        '| --- | --- | --- |'
-    ) + @($projectResults | ForEach-Object { "| $($_.project) | $($_.status) | `$($_.path)/` |" })
-    Write-AtomicTextFile -Path (Join-Path $benchmarkRun.RunDirectory 'report.md') -Content ($markdown -join [Environment]::NewLine)
-    Complete-ArtifactRun -RunDirectory $benchmarkRun.RunDirectory -Status $report.status `
-        -AdditionalValues @{ projects = @($projectResults); report = 'report.json'; comparable = (-not $diagnostics) }
+
     Write-Host "Benchmark run: $($benchmarkRun.RunDirectory)"
     exit $(if ($failedProjects.Count -eq 0) { 0 } else { 1 })
 }

--- a/scripts/devops/commands/benchmark.ps1
+++ b/scripts/devops/commands/benchmark.ps1
@@ -36,6 +36,7 @@ function Invoke-DevOpsBenchmark {
     $list = $parsed.Has('List')
     $dry = $parsed.Has('Dry')
     $gcDump = $parsed.Has('GcDump')
+    $diagnostics = $parsed.Has('Diagnostics')
     $controlled = $parsed.Has('Controlled')
     $passThrough = $parsed.PassThrough
     $area = $parsed.Get('Area', '')
@@ -75,14 +76,7 @@ function Invoke-DevOpsBenchmark {
         exit $LASTEXITCODE
     }
 
-    $projectPath = Resolve-BenchmarkProjectPath $suite
-
-    # The Rowles.Text and Compression runners do not use the custom --suite
-    # protocol; only the core runner does.
-    $runArgs = @()
-    if ($suite -notin @('text', 'compression')) {
-        $runArgs += @('--suite', $suite)
-    }
+    $projectKeys = if ($suite -eq 'all') { @('core', 'text', 'compression') } elseif ($suite -in @('core', 'text', 'compression')) { @($suite) } else { @('core') }
 
     $stratCfg = Resolve-BenchmarkStrategy $strat
     $stratDocCount = $stratCfg.DocCount
@@ -111,10 +105,8 @@ function Invoke-DevOpsBenchmark {
     }
 
     if ($effectiveDocCount -gt 0) {
-        $runArgs += @('--doccount', $effectiveDocCount.ToString())
         $env:BENCH_DOC_COUNT = $effectiveDocCount.ToString()
     }
-    if ($corpusOnly) { $runArgs += '--corpus-only' }
     if ($sourceCommit)   { $env:BENCH_SOURCE_COMMIT   = $sourceCommit }
     if ($sourceRef)      { $env:BENCH_SOURCE_REF      = $sourceRef }
     if ($sourceManifest) { $env:BENCH_SOURCE_MANIFEST = [System.IO.Path]::GetFullPath($sourceManifest) }
@@ -127,23 +119,84 @@ function Invoke-DevOpsBenchmark {
     if ($effectiveDocCount -gt 0) { Write-Host "Docs:       $effectiveDocCount" }
     if ($stratJobArgs)   { Write-Host "Job:        $($stratJobArgs -join ' ')" }
     if ($passThrough)    { Write-Host "BDN args:   $($passThrough -join ' ')" }
+    Write-Host "Projects:   $($projectKeys -join ', ')"
+    if ($diagnostics)    { Write-Warn 'Diagnostic benchmark telemetry is non-comparable performance data.' }
 
     if ($dry) {
         Write-Host ''
-        Write-Host 'Dry run - command that would execute:'
-        Write-Host "  dotnet run -c Release --framework $framework --project `"$projectPath`" -- $($runArgs -join ' ') $($stratJobArgs -join ' ') $($passThrough -join ' ')"
+        Write-Host 'Dry run - commands that would execute:'
+        foreach ($projectKey in $projectKeys) {
+            $projectPath = Resolve-BenchmarkProjectPath $projectKey
+            $runArgs = if ($projectKey -eq 'core') { @('--suite', $(if ($suite -in @('all', 'core')) { 'all' } else { $suite })) } else { @() }
+            if ($effectiveDocCount -gt 0 -and $projectKey -eq 'core') { $runArgs += @('--doccount', $effectiveDocCount.ToString()) }
+            if ($corpusOnly -and $projectKey -eq 'core') { $runArgs += '--corpus-only' }
+            Write-Host "  dotnet run -c Release --framework $framework --project `"$projectPath`" -- $($runArgs -join ' ') $($stratJobArgs -join ' ') $($passThrough -join ' ')"
+        }
         Write-Host ''
         exit 0
     }
 
     if ($gcDump) {
-        $runArgs += '--gcdump'
         Assert-DotNetTool 'dotnet-gcdump'
     }
 
     Write-Host ''
-    dotnet run -c Release --framework $framework --project $projectPath -- @runArgs @stratJobArgs @passThrough
-    exit $LASTEXITCODE
+    $commandLine = ConvertTo-CommandLineText -Command './devops benchmark' -Arguments $Arguments
+    $benchmarkRun = New-ArtifactRun -Kind benchmark -Framework $framework -Configuration Release `
+        -Target $suite -CommandLine $commandLine -RepoRoot $repoRoot
+    $projectResults = [System.Collections.Generic.List[object]]::new()
+    try {
+        foreach ($projectKey in $projectKeys) {
+            $projectPath = Resolve-BenchmarkProjectPath $projectKey
+            $projectDirectory = Join-Path $benchmarkRun.RunDirectory $projectKey
+            [void][System.IO.Directory]::CreateDirectory($projectDirectory)
+            $runArgs = if ($projectKey -eq 'core') { @('--suite', $(if ($suite -in @('all', 'core')) { 'all' } else { $suite })) } else { @() }
+            if ($effectiveDocCount -gt 0 -and $projectKey -eq 'core') { $runArgs += @('--doccount', $effectiveDocCount.ToString()) }
+            if ($corpusOnly -and $projectKey -eq 'core') { $runArgs += '--corpus-only' }
+            if ($gcDump -and $projectKey -eq 'core') { $runArgs += '--gcdump' }
+
+            Set-ArtifactProcessEnvironment -RunId $benchmarkRun.RunId -Kind benchmark `
+                -ArtifactDirectory $projectDirectory -Target $projectKey -Diagnostics $diagnostics
+            $env:LEANCORPUS_TELEMETRY = if ($diagnostics) { 'full' } else { 'off' }
+            Write-Info "Running benchmark project: $projectKey"
+            dotnet run -c Release --framework $framework --project $projectPath -- @runArgs @stratJobArgs @passThrough
+            $exitCode = $LASTEXITCODE
+            [void]$projectResults.Add([ordered]@{
+                project = $projectKey
+                status = if ($exitCode -eq 0) { 'Passed' } else { 'Failed' }
+                exitCode = $exitCode
+                path = $projectKey
+            })
+        }
+    } finally {
+        Clear-ArtifactProcessEnvironment
+    }
+
+    $failedProjects = @($projectResults | Where-Object { $_.status -ne 'Passed' })
+    $report = [ordered]@{
+        schemaVersion = 1
+        runId = $benchmarkRun.RunId
+        status = if ($failedProjects.Count -eq 0) { 'Passed' } else { 'Failed' }
+        framework = $framework
+        strategy = $strat
+        diagnostics = $diagnostics
+        comparable = -not $diagnostics
+        projects = @($projectResults)
+    }
+    Write-AtomicJsonFile -Path (Join-Path $benchmarkRun.RunDirectory 'report.json') -Value $report
+    $markdown = @(
+        "# Benchmark run $($benchmarkRun.RunId)",
+        '',
+        "Status: $($report.status)",
+        '',
+        '| Project | Status | Path |',
+        '| --- | --- | --- |'
+    ) + @($projectResults | ForEach-Object { "| $($_.project) | $($_.status) | `$($_.path)/` |" })
+    Write-AtomicTextFile -Path (Join-Path $benchmarkRun.RunDirectory 'report.md') -Content ($markdown -join [Environment]::NewLine)
+    Complete-ArtifactRun -RunDirectory $benchmarkRun.RunDirectory -Status $report.status `
+        -AdditionalValues @{ projects = @($projectResults); report = 'report.json'; comparable = (-not $diagnostics) }
+    Write-Host "Benchmark run: $($benchmarkRun.RunDirectory)"
+    exit $(if ($failedProjects.Count -eq 0) { 0 } else { 1 })
 }
 
 function Resolve-BenchmarkProjectPath {

--- a/scripts/devops/commands/clean.ps1
+++ b/scripts/devops/commands/clean.ps1
@@ -1,0 +1,17 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Invoke-DevOpsClean {
+    param([string[]]$Arguments = @())
+    try {
+        $parsed = ConvertFrom-DevOpsArguments $Arguments
+        $target = if ($parsed.Positionals.Count -gt 0) { [string]$parsed.Positionals[0] } else { 'default' }
+        Write-Heading "Cleaning LeanCorpus artefacts: $target"
+        Invoke-ArtifactClean -Target $target
+        Write-Success 'Artefact cleaning completed.'
+        return 0
+    } catch {
+        Write-Failure "Clean command failed: $($_.Exception.Message)"
+        return 1
+    }
+}

--- a/scripts/devops/commands/coverage.ps1
+++ b/scripts/devops/commands/coverage.ps1
@@ -30,6 +30,8 @@ function Invoke-DevOpsCoverage {
         $commandLine = ConvertTo-CommandLineText -Command './devops coverage' -Arguments $Arguments
         $coverageRun = New-ArtifactRun -Kind coverage -Framework $framework -Configuration $configuration `
             -Target $suite -CommandLine $commandLine -RepoRoot $repoRoot
+        Update-ArtifactRunManifest -RunDirectory $coverageRun.RunDirectory `
+            -Values @{ testRunId = $coverageRun.RunId }
         $resultsDir = Join-Path $coverageRun.RunDirectory 'raw'
         [void][System.IO.Directory]::CreateDirectory($resultsDir)
 
@@ -68,7 +70,7 @@ function Invoke-DevOpsCoverage {
         }
 
         $exitCode = Invoke-TestPipeline -Targets $targets -Options $options -CommandLine $commandLine `
-            -DisplayName 'Coverage test run' -RepoRoot $repoRoot
+            -DisplayName 'Coverage test run' -RunId $coverageRun.RunId -RepoRoot $repoRoot
 
         $xmlFiles = @(Find-CoverageResults $resultsDir)
         Write-Host ''
@@ -81,7 +83,7 @@ function Invoke-DevOpsCoverage {
 
         $coverageStatus = if ($exitCode -eq 0 -and $xmlFiles.Count -gt 0) { 'Passed' } else { 'Failed' }
         Complete-ArtifactRun -RunDirectory $coverageRun.RunDirectory -Status $coverageStatus `
-            -AdditionalValues @{ coverageFiles = $xmlFiles.Count; raw = 'raw' }
+            -AdditionalValues @{ coverageFiles = $xmlFiles.Count; raw = 'raw'; testRunId = $coverageRun.RunId }
         $runCompleted = $true
 
         return $(if ($coverageStatus -eq 'Passed') { 0 } else { 1 })

--- a/scripts/devops/commands/coverage.ps1
+++ b/scripts/devops/commands/coverage.ps1
@@ -4,6 +4,8 @@ Set-StrictMode -Version Latest
 function Invoke-DevOpsCoverage {
     param([string[]]$Arguments = @())
 
+    $coverageRun = $null
+    $runCompleted = $false
     try {
         $parsed = ConvertFrom-DevOpsArguments $Arguments
         $frameworkWasSpecified = $parsed.Has('Framework')
@@ -80,10 +82,30 @@ function Invoke-DevOpsCoverage {
         $coverageStatus = if ($exitCode -eq 0 -and $xmlFiles.Count -gt 0) { 'Passed' } else { 'Failed' }
         Complete-ArtifactRun -RunDirectory $coverageRun.RunDirectory -Status $coverageStatus `
             -AdditionalValues @{ coverageFiles = $xmlFiles.Count; raw = 'raw' }
+        $runCompleted = $true
 
-        return $exitCode
+        return $(if ($coverageStatus -eq 'Passed') { 0 } else { 1 })
     } catch {
         Write-Failure "Coverage command failed: $($_.Exception.Message)"
+        if ($null -ne $coverageRun -and -not $runCompleted) {
+            try {
+                Complete-ArtifactRun -RunDirectory $coverageRun.RunDirectory -Status Failed `
+                    -AdditionalValues @{ error = $_.Exception.Message }
+                $runCompleted = $true
+            } catch {
+                Write-Warn "Coverage run could not be finalised as Failed: $($_.Exception.Message)"
+            }
+        }
         return 1
+    } finally {
+        if ($null -ne $coverageRun -and -not $runCompleted) {
+            try {
+                Complete-ArtifactRun -RunDirectory $coverageRun.RunDirectory -Status Incomplete `
+                    -AdditionalValues @{ error = 'Coverage command did not complete normally.' }
+                $runCompleted = $true
+            } catch {
+                Write-Warn "Coverage run remained unfinalised: $($_.Exception.Message)"
+            }
+        }
     }
 }

--- a/scripts/devops/commands/coverage.ps1
+++ b/scripts/devops/commands/coverage.ps1
@@ -21,10 +21,14 @@ function Invoke-DevOpsCoverage {
             throw "Unknown or ineligible coverage suite '$suite'. Eligible suites: $($eligibleSuites -join ', ')."
         }
 
-        $resultsDir = Join-Path $repoRoot 'coverage-results'
-        if ($clean -and (Test-Path $resultsDir)) {
-            Remove-Item $resultsDir -Recurse -Force
+        $coverageRoot = Get-ArtifactKindRoot -Kind coverage -RepoRoot $repoRoot
+        if ($clean -and (Test-Path $coverageRoot)) {
+            Remove-OwnedArtifactPath -Path $coverageRoot -ArtifactRoot (Get-ArtifactRoot -RepoRoot $repoRoot)
         }
+        $commandLine = ConvertTo-CommandLineText -Command './devops coverage' -Arguments $Arguments
+        $coverageRun = New-ArtifactRun -Kind coverage -Framework $framework -Configuration $configuration `
+            -Target $suite -CommandLine $commandLine -RepoRoot $repoRoot
+        $resultsDir = Join-Path $coverageRun.RunDirectory 'raw'
         [void][System.IO.Directory]::CreateDirectory($resultsDir)
 
         $filter = if ($includePerformance) { '' } else { 'Coverage!=Skip' }
@@ -43,6 +47,9 @@ function Invoke-DevOpsCoverage {
             Diagnostics = $false
             Ci = $false
             CollectCoverage = $true
+            ExplicitMode = 'off'
+            ParallelProfile = 'integration'
+            FailWarnings = $false
             ArtifactsEnabled = $true
             Configuration = $configuration
             RequestedFramework = if ($frameworkWasSpecified) { $framework } else { '' }
@@ -58,18 +65,21 @@ function Invoke-DevOpsCoverage {
             CoverageResultsDirectory = $resultsDir
         }
 
-        $commandLine = ConvertTo-CommandLineText -Command './devops coverage' -Arguments $Arguments
         $exitCode = Invoke-TestPipeline -Targets $targets -Options $options -CommandLine $commandLine `
             -DisplayName 'Coverage test run' -RepoRoot $repoRoot
 
         $xmlFiles = @(Find-CoverageResults $resultsDir)
         Write-Host ''
-        Write-Success "Coverage data written to: $resultsDir"
+        Write-Success "Coverage data written to: $($coverageRun.RunDirectory)"
         Write-Host "  Found $($xmlFiles.Count) coverage file(s)."
 
         if ($generateReport -and $xmlFiles.Count -gt 0) {
-            New-CoverageReport -XmlFiles $xmlFiles -OutputDir (Join-Path $repoRoot 'docs/coverage')
+            New-CoverageReport -XmlFiles $xmlFiles -OutputDir (Join-Path $coverageRun.RunDirectory 'html')
         }
+
+        $coverageStatus = if ($exitCode -eq 0 -and $xmlFiles.Count -gt 0) { 'Passed' } else { 'Failed' }
+        Complete-ArtifactRun -RunDirectory $coverageRun.RunDirectory -Status $coverageStatus `
+            -AdditionalValues @{ coverageFiles = $xmlFiles.Count; raw = 'raw' }
 
         return $exitCode
     } catch {

--- a/scripts/devops/commands/docs.ps1
+++ b/scripts/devops/commands/docs.ps1
@@ -92,9 +92,11 @@ function Invoke-DevOpsDocs {
         $coverageOutput = Get-DocsArtifactPath -Name coverage -RepoRoot $repoRoot
         $coverageRun = $null
         $gitContext = Get-ArtifactGitContext -RepoRoot $repoRoot
-        if ($gitContext.commit) {
+        if ($gitContext.commit -and -not $gitContext.dirty) {
             $coverageRun = Get-LatestSuccessfulArtifactRun -Kind coverage -RepoRoot $repoRoot `
                 -Commit $gitContext.commit
+        } elseif ($gitContext.dirty) {
+            Write-Info 'Current working tree is dirty; retained coverage evidence will not be reused.'
         }
 
         $xmlFiles = @(

--- a/scripts/devops/commands/docs.ps1
+++ b/scripts/devops/commands/docs.ps1
@@ -89,9 +89,24 @@ function Invoke-DevOpsDocs {
     }
 
     if (-not $skipCoverage) {
-        $xmlFiles = @(Find-CoverageResults (Get-ArtifactRunsRoot -Kind coverage -RepoRoot $repoRoot))
+        $coverageOutput = Get-DocsArtifactPath -Name coverage -RepoRoot $repoRoot
+        $coverageRun = $null
+        $gitContext = Get-ArtifactGitContext -RepoRoot $repoRoot
+        if ($gitContext.commit) {
+            $coverageRun = Get-LatestSuccessfulArtifactRun -Kind coverage -RepoRoot $repoRoot `
+                -Commit $gitContext.commit
+        }
+
+        $xmlFiles = @(
+            if ($null -ne $coverageRun) {
+                Find-CoverageResults (Join-Path $coverageRun.RunDirectory 'raw')
+            }
+        )
         if ($xmlFiles.Count -gt 0) {
-            New-CoverageReport -XmlFiles $xmlFiles -OutputDir (Get-DocsArtifactPath -Name coverage -RepoRoot $repoRoot)
+            New-CoverageReport -XmlFiles $xmlFiles -OutputDir $coverageOutput
+        } else {
+            Remove-OwnedArtifactPath -Path $coverageOutput -ArtifactRoot (Get-ArtifactRoot -RepoRoot $repoRoot)
+            Write-Info 'Current-commit coverage evidence is unavailable; continuing without a coverage report.'
         }
     }
 

--- a/scripts/devops/commands/docs.ps1
+++ b/scripts/devops/commands/docs.ps1
@@ -21,9 +21,9 @@ function Invoke-DevOpsDocs {
 
     $docsDir  = Join-Path $repoRoot 'docs'
     $docfxJson = Join-Path $docsDir 'docfx.json'
-    $apiDir   = Join-Path $docsDir 'api'
-    $siteDir  = Join-Path $docsDir 'site'
-    $diagnosticsDir = Join-Path $repoRoot 'artifacts/docs'
+    $apiDir   = Get-DocsArtifactPath -Name api -RepoRoot $repoRoot
+    $siteDir  = Get-DocsArtifactPath -Name site -RepoRoot $repoRoot
+    $diagnosticsDir = Get-DocsArtifactPath -Name diagnostics -RepoRoot $repoRoot
     $metadataLog = Join-Path $diagnosticsDir 'docfx-metadata.jsonl'
     $buildLog = Join-Path $diagnosticsDir 'docfx-build.jsonl'
 
@@ -40,11 +40,11 @@ function Invoke-DevOpsDocs {
     }
 
     function Invoke-MetadataRegeneration {
-        Clear-ApiMetadata $docsDir
+        Clear-ApiMetadata $apiDir
         Write-Heading 'Generating API metadata...'
         $exitCode = Invoke-DocfxWithDiagnostics -Command metadata -ConfigPath $docfxJson -LogPath $metadataLog
         if ($exitCode -ne 0) { exit $exitCode }
-        Remove-ExternalInheritedMembers $docsDir
+        Remove-ExternalInheritedMembers $apiDir
     }
 
     if ($subCmd -eq 'metadata') {
@@ -78,13 +78,20 @@ function Invoke-DevOpsDocs {
 
     if (-not $skipBenchmarks) {
         Write-Heading 'Generating benchmark pages...'
-        & (Join-Path $scriptsPath 'benchmarks/generate-docs.ps1')
+        & (Join-Path $scriptsPath 'benchmarks/generate-docs.ps1') `
+            -OutputDir (Join-Path (Get-DocsArtifactPath -Name generated -RepoRoot $repoRoot) 'benchmarks')
+    } else {
+        $benchmarkStaging = Join-Path (Get-DocsArtifactPath -Name generated -RepoRoot $repoRoot) 'benchmarks'
+        [void][System.IO.Directory]::CreateDirectory($benchmarkStaging)
+        Get-ChildItem (Join-Path $docsDir 'benchmarks') -File | ForEach-Object {
+            Copy-Item -LiteralPath $_.FullName -Destination (Join-Path $benchmarkStaging $_.Name) -Force
+        }
     }
 
     if (-not $skipCoverage) {
-        $xmlFiles = @(Find-CoverageResults (Join-Path $repoRoot 'coverage-results'))
+        $xmlFiles = @(Find-CoverageResults (Get-ArtifactRunsRoot -Kind coverage -RepoRoot $repoRoot))
         if ($xmlFiles.Count -gt 0) {
-            New-CoverageReport -XmlFiles $xmlFiles -OutputDir (Join-Path $docsDir 'coverage')
+            New-CoverageReport -XmlFiles $xmlFiles -OutputDir (Get-DocsArtifactPath -Name coverage -RepoRoot $repoRoot)
         }
     }
 

--- a/scripts/devops/commands/pack.ps1
+++ b/scripts/devops/commands/pack.ps1
@@ -1,0 +1,50 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Invoke-DevOpsPack {
+    param([string[]]$Arguments = @())
+    try {
+        $parsed = ConvertFrom-DevOpsArguments $Arguments
+        $repoRoot = Get-RepoRoot
+        $configuration = [string]$parsed.Get('Configuration', 'Release')
+        $outputDirectory = Join-Path (Get-ArtifactKindRoot -Kind package -RepoRoot $repoRoot) 'release'
+        if ($parsed.Has('Clean') -and (Test-Path $outputDirectory)) {
+            Remove-OwnedArtifactPath -Path $outputDirectory -ArtifactRoot (Get-ArtifactRoot -RepoRoot $repoRoot)
+        }
+        [void][System.IO.Directory]::CreateDirectory($outputDirectory)
+
+        $arguments = @('pack', (Join-Path $repoRoot 'Rowles.LeanCorpus.slnx'), '-c', $configuration, '--output', $outputDirectory)
+        if ($parsed.Has('NoBuild')) { $arguments += '--no-build' }
+        Write-Heading 'Packing LeanCorpus packages'
+        Invoke-DotNet $arguments
+
+        $git = Get-ArtifactGitContext -RepoRoot $repoRoot
+        $packages = @(Get-ChildItem $outputDirectory -File | Where-Object { $_.Extension -in @('.nupkg', '.snupkg') } | Sort-Object Name)
+        $entries = foreach ($package in $packages) {
+            $name = [System.IO.Path]::GetFileNameWithoutExtension($package.Name)
+            if ($package.Name.EndsWith('.snupkg', [StringComparison]::OrdinalIgnoreCase)) {
+                $name = [System.IO.Path]::GetFileNameWithoutExtension($name)
+            }
+            $match = [regex]::Match($name, '^(?<id>.+)\.(?<version>\d+\.\d+\.\d+(?:[-+].+)?)$')
+            [ordered]@{
+                packageId = if ($match.Success) { $match.Groups['id'].Value } else { $name }
+                version = if ($match.Success) { $match.Groups['version'].Value } else { '' }
+                path = $package.Name
+                size = $package.Length
+                sha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $package.FullName).Hash.ToLowerInvariant()
+            }
+        }
+        Write-AtomicJsonFile -Path (Join-Path $outputDirectory 'manifest.json') -Value ([ordered]@{
+            schemaVersion = 1
+            generatedAtUtc = [DateTime]::UtcNow.ToString('O')
+            sourceCommit = $git.commit
+            configuration = $configuration
+            packages = @($entries)
+        })
+        Write-Success "Packages written to: $outputDirectory"
+        return 0
+    } catch {
+        Write-Failure "Pack command failed: $($_.Exception.Message)"
+        return 1
+    }
+}

--- a/scripts/devops/commands/setup.ps1
+++ b/scripts/devops/commands/setup.ps1
@@ -11,18 +11,23 @@ function Invoke-DevOpsSetup {
 
     # Directories expected by devops commands, docfx, and CI
     $dirs = @(
-        'bench',
-        'bench/data',
-        'coverage-results',
-        'docs/api',
-        'docs/coverage',
-        'docs/site',
-        'docs/changelog'
+        (Get-ArtifactRunsRoot -Kind test -RepoRoot $repoRoot),
+        (Get-ArtifactRunsRoot -Kind coverage -RepoRoot $repoRoot),
+        (Get-ArtifactRunsRoot -Kind benchmark -RepoRoot $repoRoot),
+        (Get-BenchmarkDataRoot -RepoRoot $repoRoot),
+        (Get-ArtifactRunsRoot -Kind diagnostics -RepoRoot $repoRoot),
+        (Get-DocsArtifactPath -Name api -RepoRoot $repoRoot),
+        (Get-DocsArtifactPath -Name coverage -RepoRoot $repoRoot),
+        (Get-DocsArtifactPath -Name site -RepoRoot $repoRoot),
+        (Get-DocsArtifactPath -Name diagnostics -RepoRoot $repoRoot),
+        (Get-ArtifactKindRoot -Kind package -RepoRoot $repoRoot),
+        (Get-ArtifactKindRoot -Kind temp -RepoRoot $repoRoot),
+        (Join-Path $repoRoot 'docs/changelog')
     )
 
     Write-Heading 'Directories'
-    foreach ($dir in $dirs) {
-        $path = Join-Path $repoRoot $dir
+    foreach ($path in $dirs) {
+        $dir = [System.IO.Path]::GetRelativePath($repoRoot, $path)
         if (-not (Test-Path $path)) {
             New-Item -ItemType Directory -Path $path | Out-Null
             Write-Success "  created $dir"

--- a/scripts/devops/commands/test.ps1
+++ b/scripts/devops/commands/test.ps1
@@ -76,6 +76,14 @@ function Invoke-DevOpsTest {
         $failFast = $parsed.Has('FailFast')
         $ci = $parsed.Has('Ci')
         $collectCoverage = $parsed.Has('CollectCoverage')
+        $explicitMode = if ($parsed.Has('ExplicitOnly')) { 'only' } elseif ($parsed.Has('Explicit')) { 'on' } else { 'off' }
+        $parallelProfile = [string]$parsed.Get('Profile', '')
+        if (-not $parallelProfile) {
+            $parallelProfile = if ($category -eq 'Unit') { 'unit' } elseif ($flaky) { 'stress' } else { 'integration' }
+        }
+        if ($parallelProfile -notin @('unit', 'integration', 'stress')) {
+            throw "Unknown test profile '$parallelProfile'. Valid: unit, integration, stress."
+        }
         $verbosity = [string]$parsed.Get('Verbosity', '')
         $artifactsEnabled = $count -gt 1 -or $flaky -or $diagnostics -or $ci -or $collectCoverage
 
@@ -95,6 +103,9 @@ function Invoke-DevOpsTest {
             Diagnostics = $diagnostics
             Ci = $ci
             CollectCoverage = $collectCoverage
+            ExplicitMode = $explicitMode
+            ParallelProfile = $parallelProfile
+            FailWarnings = $parsed.Has('FailWarnings')
             ArtifactsEnabled = $artifactsEnabled
             Configuration = $configuration
             RequestedFramework = if ($frameworkWasSpecified) { $framework } else { '' }

--- a/scripts/devops/diagnostics/tools.ps1
+++ b/scripts/devops/diagnostics/tools.ps1
@@ -23,9 +23,9 @@ function New-DiagnosticsContext {
         [string]$Tool = ''
     )
 
-    $runId = Get-TestRunId
-    $runDirectory = Join-Path $RepoRoot "artifacts/diagnostics/$runId"
-    [void][System.IO.Directory]::CreateDirectory($runDirectory)
+    $run = New-ArtifactRun -Kind diagnostics -Target $Tool -CommandLine $CommandLine -RepoRoot $RepoRoot
+    $runId = $run.RunId
+    $runDirectory = $run.RunDirectory
 
     $context = [pscustomobject]@{
         RunId = $runId
@@ -38,7 +38,7 @@ function New-DiagnosticsContext {
         EndTimeUtc = $null
         Outputs = [System.Collections.Generic.List[string]]::new()
         Warnings = [System.Collections.Generic.List[string]]::new()
-        MetadataPath = Join-Path $runDirectory 'metadata.json'
+        MetadataPath = Join-Path $runDirectory 'run.json'
         EnvironmentPath = Join-Path $runDirectory 'environment.json'
     }
 
@@ -63,11 +63,9 @@ function Update-DiagnosticsMetadata {
         ([DateTime]::UtcNow - $Context.StartTimeUtc).TotalMilliseconds
     }
 
-    $document = [ordered]@{
-        schemaVersion = 1
-        runId = $Context.RunId
-        commandLine = $Context.CommandLine
+    $values = @{
         status = $Status
+        completedAtUtc = if ($Context.EndTimeUtc) { $Context.EndTimeUtc.ToString('O') } else { $null }
         startTimeUtc = $Context.StartTimeUtc.ToString('O')
         endTimeUtc = if ($Context.EndTimeUtc) { $Context.EndTimeUtc.ToString('O') } else { $null }
         durationMs = [Math]::Round($durationMs, 3)
@@ -78,7 +76,7 @@ function Update-DiagnosticsMetadata {
         error = $ErrorMessage
         environmentPath = 'environment.json'
     }
-    Write-AtomicJsonFile -Path $Context.MetadataPath -Value $document
+    Update-ArtifactRunManifest -RunDirectory $Context.RunDirectory -Values $values
 }
 
 function Resolve-DiagnosticProcess {

--- a/scripts/devops/diagnostics/tools.ps1
+++ b/scripts/devops/diagnostics/tools.ps1
@@ -42,9 +42,19 @@ function New-DiagnosticsContext {
         EnvironmentPath = Join-Path $runDirectory 'environment.json'
     }
 
-    $environment = Get-TestEnvironmentSnapshot -RepoRoot $RepoRoot -CommandLine $CommandLine
-    Write-AtomicJsonFile -Path $context.EnvironmentPath -Value $environment
-    Update-DiagnosticsMetadata -Context $context -Status 'Running'
+    try {
+        $environment = Get-TestEnvironmentSnapshot -RepoRoot $RepoRoot -CommandLine $CommandLine
+        Write-AtomicJsonFile -Path $context.EnvironmentPath -Value $environment
+        Update-DiagnosticsMetadata -Context $context -Status 'Running'
+    } catch {
+        try {
+            Complete-ArtifactRun -RunDirectory $runDirectory -Status Failed `
+                -AdditionalValues @{ error = $_.Exception.Message }
+        } catch {
+            # Preserve the original setup failure if its evidence cannot be written.
+        }
+        throw
+    }
     return $context
 }
 

--- a/scripts/devops/support/benchmark.ps1
+++ b/scripts/devops/support/benchmark.ps1
@@ -18,7 +18,7 @@ function Prepare-BenchmarkData {
         [int]$BookCount
     )
 
-    $dataDir = Join-Path $RepoRoot 'bench/data'
+    $dataDir = Get-BenchmarkDataRoot -RepoRoot $RepoRoot
     $gutenbergDir = Join-Path $dataDir 'gutenberg-ebooks'
     $newsDir = Join-Path $dataDir '20newsgroups'
     $reutersDir = Join-Path $dataDir 'reuters21578'

--- a/scripts/devops/support/docfx.ps1
+++ b/scripts/devops/support/docfx.ps1
@@ -2,9 +2,7 @@ $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
 function Clear-ApiMetadata {
-    param([string]$DocsDir)
-
-    $apiDir = Join-Path $DocsDir 'api'
+    param([string]$ApiDir)
     if (-not (Test-Path $apiDir)) {
         New-Item -ItemType Directory -Path $apiDir | Out-Null
         return
@@ -123,9 +121,7 @@ function Invoke-DocfxWithDiagnostics {
 }
 
 function Remove-ExternalInheritedMembers {
-    param([string]$DocsDir)
-
-    $apiDir = Join-Path $DocsDir 'api'
+    param([string]$ApiDir)
     if (-not (Test-Path $apiDir)) { return }
 
     foreach ($file in Get-ChildItem $apiDir -Filter '*.yml' -File) {
@@ -214,7 +210,7 @@ function Copy-RepositoryDocumentation {
         @{ Source = 'src/server/README.md'; Destination = 'contributors/server-proof-of-concept.md' }
     )
 
-    $stagingDir = Join-Path $DocsDir '.generated'
+    $stagingDir = Join-Path (Get-DocsArtifactPath -Name generated -RepoRoot $RepoRoot) 'repository'
     if (Test-Path $stagingDir) {
         Remove-Item $stagingDir -Recurse -Force
     }

--- a/scripts/devops/testing/artifacts.ps1
+++ b/scripts/devops/testing/artifacts.ps1
@@ -1,53 +1,9 @@
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
-function ConvertTo-TestJson {
-    param([object]$Value)
-
-    return ($Value | ConvertTo-Json -Depth 30)
-}
-
-function Write-AtomicTextFile {
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$Path,
-        [Parameter(Mandatory = $true)]
-        [string]$Content
-    )
-
-    $parent = Split-Path -Parent $Path
-    if ($parent) {
-        [void][System.IO.Directory]::CreateDirectory($parent)
-    }
-
-    $temporaryPath = "$Path.$([Guid]::NewGuid().ToString('N')).tmp"
-    try {
-        [System.IO.File]::WriteAllText($temporaryPath, $Content, [System.Text.UTF8Encoding]::new($false))
-        [System.IO.File]::Move($temporaryPath, $Path, $true)
-    } catch {
-        if ([System.IO.File]::Exists($temporaryPath)) {
-            [System.IO.File]::Delete($temporaryPath)
-        }
-        throw
-    }
-}
-
-function Write-AtomicJsonFile {
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$Path,
-        [Parameter(Mandatory = $true)]
-        [object]$Value
-    )
-
-    Write-AtomicTextFile -Path $Path -Content (ConvertTo-TestJson $Value)
-}
-
 function Get-TestRunId {
-    $utc = [DateTime]::UtcNow
-    $processId = [Environment]::ProcessId
-    $entropy = [Guid]::NewGuid().ToString('N').Substring(0, 6)
-    return "$($utc.ToString('yyyyMMdd-HHmmss-fff'))-$processId-$entropy"
+    param([string]$Framework = '')
+    return New-ArtifactRunId -Kind test -Framework $Framework
 }
 
 function Get-TestEnvironmentSnapshot {
@@ -155,9 +111,9 @@ function New-TestRunContext {
     )
 
     $artifactsEnabled = [bool]$Options.ArtifactsEnabled
-    $runId = if ($artifactsEnabled) { Get-TestRunId } else { '' }
+    $runId = if ($artifactsEnabled) { Get-TestRunId -Framework $Options.RequestedFramework } else { '' }
     $runDirectory = if ($artifactsEnabled) {
-        Join-Path $RepoRoot "artifacts/test/runs/$runId"
+        Join-Path (Get-ArtifactRunsRoot -Kind test -RepoRoot $RepoRoot) $runId
     } else {
         ''
     }
@@ -192,7 +148,7 @@ function New-TestRunContext {
     if ($artifactsEnabled) {
         [void][System.IO.Directory]::CreateDirectory($runDirectory)
         $context.EnvironmentPath = Join-Path $runDirectory 'environment.json'
-        $context.ManifestPath = Join-Path $runDirectory 'manifest.json'
+        $context.ManifestPath = Join-Path $runDirectory 'run.json'
         $context.StatePath = Join-Path $runDirectory 'state.json'
 
         $environment = Get-TestEnvironmentSnapshot -RepoRoot $RepoRoot -CommandLine $CommandLine
@@ -201,7 +157,16 @@ function New-TestRunContext {
         $manifest = [ordered]@{
             schemaVersion = 1
             runId = $runId
+            kind = 'test'
             commandLine = $CommandLine
+            startedAtUtc = $context.StartTimeUtc.ToString('O')
+            completedAtUtc = $null
+            commit = $environment.gitCommit
+            branch = $environment.gitBranch
+            dirty = $environment.gitDirty
+            framework = $Options.RequestedFramework
+            machine = [Environment]::MachineName
+            status = 'Running'
             startTimeUtc = $context.StartTimeUtc.ToString('O')
             endTimeUtc = $null
             durationMs = 0
@@ -223,8 +188,8 @@ function New-TestRunContext {
             artifactPaths = [ordered]@{
                 environment = 'environment.json'
                 state = 'state.json'
-                summaryMarkdown = 'summary.md'
-                summaryJson = 'summary.json'
+                reportMarkdown = 'report.md'
+                reportJson = 'report.json'
                 timingsCsv = 'timings.csv'
             }
         }
@@ -298,8 +263,8 @@ function Get-TestTargetArtifactDirectory {
         return ''
     }
 
-    $iterationDirectory = Join-Path $Context.RunDirectory ("iteration-{0:D3}" -f $Iteration)
-    $targetDirectory = Join-Path $iterationDirectory $Target.ArtifactName
+    $targetDirectory = Join-Path (Join-Path $Context.RunDirectory 'targets') $Target.ArtifactName
+    $targetDirectory = Join-Path $targetDirectory ("{0:D3}" -f $Iteration)
     [void][System.IO.Directory]::CreateDirectory($targetDirectory)
     [void][System.IO.Directory]::CreateDirectory((Join-Path $targetDirectory 'diagnostics'))
     return $targetDirectory
@@ -476,6 +441,10 @@ function Update-TestRunManifest {
     $manifest = [ordered]@{
         schemaVersion = 1
         runId = $Context.RunId
+        kind = 'test'
+        status = if ($null -ne $Summary -and [bool]$Summary.Succeeded) { 'Passed' } else { 'Failed' }
+        startedAtUtc = $Context.StartTimeUtc.ToString('O')
+        completedAtUtc = $Context.EndTimeUtc.ToString('O')
         commandLine = $Context.CommandLine
         startTimeUtc = $Context.StartTimeUtc.ToString('O')
         endTimeUtc = $Context.EndTimeUtc.ToString('O')
@@ -483,9 +452,14 @@ function Update-TestRunManifest {
         gitCommit = ''
         gitBranch = ''
         gitDirty = $false
+        commit = ''
+        branch = ''
+        dirty = $false
         os = ''
         architecture = ''
+        machine = [Environment]::MachineName
         sdkVersion = ''
+        framework = $Context.Options.RequestedFramework
         configuration = $Context.Options.Configuration
         requestedFramework = $Context.Options.RequestedFramework
         runtimeIdentifier = $Context.Options.RuntimeIdentifier
@@ -498,8 +472,8 @@ function Update-TestRunManifest {
         artifactPaths = [ordered]@{
             environment = Get-TestArtifactRelativePath -Context $Context -Path $Context.EnvironmentPath
             state = Get-TestArtifactRelativePath -Context $Context -Path $Context.StatePath
-            summaryMarkdown = 'summary.md'
-            summaryJson = 'summary.json'
+            reportMarkdown = 'report.md'
+            reportJson = 'report.json'
             timingsCsv = 'timings.csv'
         }
         stageTimings = @($Context.StageTimings)
@@ -534,6 +508,9 @@ function Update-TestRunManifest {
             $manifest.gitCommit = $environment.gitCommit
             $manifest.gitBranch = $environment.gitBranch
             $manifest.gitDirty = [bool]$environment.gitDirty
+            $manifest.commit = $environment.gitCommit
+            $manifest.branch = $environment.gitBranch
+            $manifest.dirty = [bool]$environment.gitDirty
             $manifest.os = $environment.os
             $manifest.architecture = $environment.architecture
             $manifest.sdkVersion = $environment.sdkVersion

--- a/scripts/devops/testing/artifacts.ps1
+++ b/scripts/devops/testing/artifacts.ps1
@@ -111,11 +111,13 @@ function New-TestRunContext {
     )
 
     $artifactsEnabled = [bool]$Options.ArtifactsEnabled
-    $runId = if ($artifactsEnabled) { Get-TestRunId -Framework $Options.RequestedFramework } else { '' }
-    $runDirectory = if ($artifactsEnabled) {
-        Join-Path (Get-ArtifactRunsRoot -Kind test -RepoRoot $RepoRoot) $runId
-    } else {
-        ''
+    $runId = ''
+    $runDirectory = ''
+    if ($artifactsEnabled) {
+        $runId = Get-TestRunId -Framework $Options.RequestedFramework
+        $artifactRun = New-ArtifactRun -Kind test -Framework $Options.RequestedFramework `
+            -Configuration $Options.Configuration -CommandLine $CommandLine -RepoRoot $RepoRoot -RunId $runId
+        $runDirectory = $artifactRun.RunDirectory
     }
 
     $context = [pscustomobject]@{
@@ -146,55 +148,48 @@ function New-TestRunContext {
     }
 
     if ($artifactsEnabled) {
-        [void][System.IO.Directory]::CreateDirectory($runDirectory)
-        $context.EnvironmentPath = Join-Path $runDirectory 'environment.json'
-        $context.ManifestPath = Join-Path $runDirectory 'run.json'
-        $context.StatePath = Join-Path $runDirectory 'state.json'
+        try {
+            $context.EnvironmentPath = Join-Path $runDirectory 'environment.json'
+            $context.ManifestPath = Join-Path $runDirectory 'run.json'
+            $context.StatePath = Join-Path $runDirectory 'state.json'
 
-        $environment = Get-TestEnvironmentSnapshot -RepoRoot $RepoRoot -CommandLine $CommandLine
-        Write-AtomicJsonFile -Path $context.EnvironmentPath -Value $environment
+            $environment = Get-TestEnvironmentSnapshot -RepoRoot $RepoRoot -CommandLine $CommandLine
+            Write-AtomicJsonFile -Path $context.EnvironmentPath -Value $environment
 
-        $manifest = [ordered]@{
-            schemaVersion = 1
-            runId = $runId
-            kind = 'test'
-            commandLine = $CommandLine
-            startedAtUtc = $context.StartTimeUtc.ToString('O')
-            completedAtUtc = $null
-            commit = $environment.gitCommit
-            branch = $environment.gitBranch
-            dirty = $environment.gitDirty
-            framework = $Options.RequestedFramework
-            machine = [Environment]::MachineName
-            status = 'Running'
-            startTimeUtc = $context.StartTimeUtc.ToString('O')
-            endTimeUtc = $null
-            durationMs = 0
-            gitCommit = $environment.gitCommit
-            gitBranch = $environment.gitBranch
-            gitDirty = $environment.gitDirty
-            os = $environment.os
-            architecture = $environment.architecture
-            sdkVersion = $environment.sdkVersion
-            configuration = $Options.Configuration
-            requestedFramework = $Options.RequestedFramework
-            runtimeIdentifier = $Options.RuntimeIdentifier
-            count = [int]$Options.Count
-            flaky = [bool]$Options.Flaky
-            diagnostics = [bool]$Options.Diagnostics
-            failFast = [bool]$Options.FailFast
-            ci = [bool]$Options.Ci
-            selectedTargets = @($Targets | ForEach-Object { ConvertTo-TestTargetDocument $_ })
-            artifactPaths = [ordered]@{
-                environment = 'environment.json'
-                state = 'state.json'
-                reportMarkdown = 'report.md'
-                reportJson = 'report.json'
-                timingsCsv = 'timings.csv'
+            $initialValues = @{
+                startTimeUtc = $context.StartTimeUtc.ToString('O')
+                endTimeUtc = $null
+                durationMs = 0
+                gitCommit = $environment.gitCommit
+                gitBranch = $environment.gitBranch
+                gitDirty = $environment.gitDirty
+                sdkVersion = $environment.sdkVersion
+                requestedFramework = $Options.RequestedFramework
+                runtimeIdentifier = $Options.RuntimeIdentifier
+                count = [int]$Options.Count
+                flaky = [bool]$Options.Flaky
+                diagnostics = [bool]$Options.Diagnostics
+                failFast = [bool]$Options.FailFast
+                selectedTargets = @($Targets | ForEach-Object { ConvertTo-TestTargetDocument $_ })
+                artifactPaths = [ordered]@{
+                    environment = 'environment.json'
+                    state = 'state.json'
+                    reportMarkdown = 'report.md'
+                    reportJson = 'report.json'
+                    timingsCsv = 'timings.csv'
+                }
             }
+            Update-ArtifactRunManifest -RunDirectory $runDirectory -Values $initialValues
+            Write-TestRunCheckpoint -Context $context -Status 'Running'
+        } catch {
+            try {
+                Complete-ArtifactRun -RunDirectory $runDirectory -Status Failed `
+                    -AdditionalValues @{ error = $_.Exception.Message }
+            } catch {
+                # Preserve the original setup failure if its evidence cannot be written.
+            }
+            throw
         }
-        Write-AtomicJsonFile -Path $context.ManifestPath -Value $manifest
-        Write-TestRunCheckpoint -Context $context -Status 'Running'
     }
 
     return $context
@@ -429,45 +424,39 @@ function Update-TestRunManifest {
     param(
         [Parameter(Mandatory = $true)]
         [object]$Context,
-        [object]$Summary = $null
+        [object]$Summary = $null,
+        [ValidateSet('Passed', 'Failed', 'Incomplete', 'Cancelled')]
+        [string]$Status = 'Failed'
     )
 
     if (-not $Context.ArtifactsEnabled) {
         return
     }
 
-    $Context.EndTimeUtc = [DateTime]::UtcNow
+    if ($null -eq $Context.EndTimeUtc) {
+        $Context.EndTimeUtc = [DateTime]::UtcNow
+    }
     $durationMs = ($Context.EndTimeUtc - $Context.StartTimeUtc).TotalMilliseconds
-    $manifest = [ordered]@{
-        schemaVersion = 1
-        runId = $Context.RunId
-        kind = 'test'
-        status = if ($null -ne $Summary -and [bool]$Summary.Succeeded) { 'Passed' } else { 'Failed' }
-        startedAtUtc = $Context.StartTimeUtc.ToString('O')
-        completedAtUtc = $Context.EndTimeUtc.ToString('O')
-        commandLine = $Context.CommandLine
+    $environment = $null
+    try {
+        if (Test-Path $Context.EnvironmentPath) {
+            $environment = Get-Content $Context.EnvironmentPath -Raw | ConvertFrom-Json
+        }
+    } catch {
+        [void]$Context.ReportErrors.Add("Manifest environment read failed: $($_.Exception.Message)")
+    }
+
+    $values = @{
         startTimeUtc = $Context.StartTimeUtc.ToString('O')
         endTimeUtc = $Context.EndTimeUtc.ToString('O')
         durationMs = [Math]::Round($durationMs, 3)
-        gitCommit = ''
-        gitBranch = ''
-        gitDirty = $false
-        commit = ''
-        branch = ''
-        dirty = $false
-        os = ''
-        architecture = ''
-        machine = [Environment]::MachineName
-        sdkVersion = ''
-        framework = $Context.Options.RequestedFramework
-        configuration = $Context.Options.Configuration
         requestedFramework = $Context.Options.RequestedFramework
         runtimeIdentifier = $Context.Options.RuntimeIdentifier
+        sdkVersion = if ($null -ne $environment) { $environment.sdkVersion } else { '' }
         count = [int]$Context.Options.Count
         flaky = [bool]$Context.Options.Flaky
         diagnostics = [bool]$Context.Options.Diagnostics
         failFast = [bool]$Context.Options.FailFast
-        ci = [bool]$Context.Options.Ci
         selectedTargets = @($Context.Targets | ForEach-Object { ConvertTo-TestTargetDocument $_ })
         artifactPaths = [ordered]@{
             environment = Get-TestArtifactRelativePath -Context $Context -Path $Context.EnvironmentPath
@@ -489,7 +478,7 @@ function Update-TestRunManifest {
     }
 
     if ($null -ne $Summary) {
-        $manifest.summary = [ordered]@{
+        $values.summary = [ordered]@{
             succeeded = [bool]$Summary.Succeeded
             requestedIterations = [int]$Summary.RequestedIterations
             completedIterations = [int]$Summary.CompletedIterations
@@ -502,24 +491,13 @@ function Update-TestRunManifest {
         }
     }
 
-    try {
-        if (Test-Path $Context.EnvironmentPath) {
-            $environment = Get-Content -LiteralPath $Context.EnvironmentPath -Raw | ConvertFrom-Json
-            $manifest.gitCommit = $environment.gitCommit
-            $manifest.gitBranch = $environment.gitBranch
-            $manifest.gitDirty = [bool]$environment.gitDirty
-            $manifest.commit = $environment.gitCommit
-            $manifest.branch = $environment.gitBranch
-            $manifest.dirty = [bool]$environment.gitDirty
-            $manifest.os = $environment.os
-            $manifest.architecture = $environment.architecture
-            $manifest.sdkVersion = $environment.sdkVersion
-        }
-    } catch {
-        [void]$Context.ReportErrors.Add("Manifest environment update failed: $($_.Exception.Message)")
+    if ($null -ne $environment) {
+        $values.gitCommit = $environment.gitCommit
+        $values.gitBranch = $environment.gitBranch
+        $values.gitDirty = [bool]$environment.gitDirty
     }
 
-    Write-AtomicJsonFile -Path $Context.ManifestPath -Value $manifest
+    Complete-ArtifactRun -RunDirectory $Context.RunDirectory -Status $Status -AdditionalValues $values
 }
 
 function Copy-TestCoverageResults {

--- a/scripts/devops/testing/artifacts.ps1
+++ b/scripts/devops/testing/artifacts.ps1
@@ -107,14 +107,17 @@ function New-TestRunContext {
         [object[]]$Targets,
         [Parameter(Mandatory = $true)]
         [string]$CommandLine,
+        [string]$RunId = '',
         [string]$RepoRoot = (Get-RepoRoot)
     )
 
     $artifactsEnabled = [bool]$Options.ArtifactsEnabled
-    $runId = ''
+    $runId = $RunId
     $runDirectory = ''
     if ($artifactsEnabled) {
-        $runId = Get-TestRunId -Framework $Options.RequestedFramework
+        if ([string]::IsNullOrWhiteSpace($runId)) {
+            $runId = Get-TestRunId -Framework $Options.RequestedFramework
+        }
         $artifactRun = New-ArtifactRun -Kind test -Framework $Options.RequestedFramework `
             -Configuration $Options.Configuration -CommandLine $CommandLine -RepoRoot $RepoRoot -RunId $runId
         $runDirectory = $artifactRun.RunDirectory

--- a/scripts/devops/testing/execution.ps1
+++ b/scripts/devops/testing/execution.ps1
@@ -248,7 +248,7 @@ function Invoke-TestTarget {
 
     if ($Context.ArtifactsEnabled) {
         Set-ArtifactProcessEnvironment -RunId $Context.RunId -Kind test -ArtifactDirectory $artifactDirectory `
-            -Target $target.Key -Iteration $Iteration -Ci ([bool]$Context.Options.Ci) `
+            -Target $target.Key -Suite $target.Suite -Iteration $Iteration -Ci ([bool]$Context.Options.Ci) `
             -Diagnostics ([bool]$Context.Options.Diagnostics)
         $env:LEANCORPUS_TELEMETRY = if ([bool]$Context.Options.Diagnostics -or [bool]$Context.Options.Flaky) {
             'full'

--- a/scripts/devops/testing/execution.ps1
+++ b/scripts/devops/testing/execution.ps1
@@ -66,6 +66,32 @@ function Get-MtpTestArguments {
         [void]$arguments.Add('--report-xunit-trx')
         [void]$arguments.Add('--report-xunit-trx-filename')
         [void]$arguments.Add('results.trx')
+        [void]$arguments.Add('--report-xunit-ctrf')
+        [void]$arguments.Add('--report-xunit-ctrf-filename')
+        [void]$arguments.Add('results.ctrf.json')
+    }
+
+    $configPath = Join-Path $Context.RepoRoot 'scripts/devops/testing/testconfig.json'
+    [void]$arguments.Add('--xunit-config-filename')
+    [void]$arguments.Add($configPath)
+
+    if ($Context.Options.PSObject.Properties['ParallelProfile']) {
+        switch ([string]$Context.Options.ParallelProfile) {
+            'unit' { [void]$arguments.Add('--parallel'); [void]$arguments.Add('all') }
+            'stress' { [void]$arguments.Add('--parallel'); [void]$arguments.Add('all') }
+            default { [void]$arguments.Add('--parallel'); [void]$arguments.Add('collections') }
+        }
+    }
+    if ($Context.Options.PSObject.Properties['ExplicitMode']) {
+        $explicitMode = [string]$Context.Options.ExplicitMode
+        if ($explicitMode) { [void]$arguments.Add('--explicit'); [void]$arguments.Add($explicitMode) }
+    }
+    if ($Context.Options.PSObject.Properties['FailWarnings'] -and [bool]$Context.Options.FailWarnings) {
+        [void]$arguments.Add('--fail-warns')
+        [void]$arguments.Add('on')
+    }
+    if ([bool]$Context.Options.Ci) {
+        [void]$arguments.Add('--report-gh')
     }
 
     if ([bool]$Context.Options.CollectCoverage -and [bool]$Target.CoverageEligible) {
@@ -220,10 +246,26 @@ function Invoke-TestTarget {
         Write-Host "  [$ExecutionNumber/$ExecutionCount] $($target.Key) still running ($elapsedText elapsed)..." -ForegroundColor DarkGray
     }.GetNewClosure()
 
-    $processResult = Invoke-ProcessWithLifecycle -FileName $fileName -Arguments $arguments `
-        -WorkingDirectory $Context.RepoRoot -StdOutPath $stdoutPath -StdErrPath $stderrPath `
-        -CaptureOutput $Context.ArtifactsEnabled -MirrorOutput $Context.ArtifactsEnabled `
-        -Timeout $Context.Options.ProcessTimeout -OnProgress $progressCallback
+    if ($Context.ArtifactsEnabled) {
+        Set-ArtifactProcessEnvironment -RunId $Context.RunId -Kind test -ArtifactDirectory $artifactDirectory `
+            -Target $target.Key -Iteration $Iteration -Ci ([bool]$Context.Options.Ci) `
+            -Diagnostics ([bool]$Context.Options.Diagnostics)
+        $env:LEANCORPUS_TELEMETRY = if ([bool]$Context.Options.Diagnostics -or [bool]$Context.Options.Flaky) {
+            'full'
+        } elseif ([bool]$Context.Options.Ci) {
+            'summary'
+        } else {
+            'off'
+        }
+    }
+    try {
+        $processResult = Invoke-ProcessWithLifecycle -FileName $fileName -Arguments $arguments `
+            -WorkingDirectory $Context.RepoRoot -StdOutPath $stdoutPath -StdErrPath $stderrPath `
+            -CaptureOutput $Context.ArtifactsEnabled -MirrorOutput $Context.ArtifactsEnabled `
+            -Timeout $Context.Options.ProcessTimeout -OnProgress $progressCallback
+    } finally {
+        Clear-ArtifactProcessEnvironment
+    }
 
     $resultParsingDuration = [TimeSpan]::Zero
     if ($target.RunnerKind -eq 'Mtp' -and $Context.ArtifactsEnabled) {

--- a/scripts/devops/testing/preparation.ps1
+++ b/scripts/devops/testing/preparation.ps1
@@ -27,9 +27,21 @@ function Get-MtpExecutablePath {
 
     $projectPath = Resolve-TestProjectPath -Target $Target -RepoRoot $RepoRoot
     $projectName = [System.IO.Path]::GetFileNameWithoutExtension($projectPath)
-    $configurationName = $Target.Configuration.ToLowerInvariant()
-    $outputDirectory = Join-Path (Get-ArtifactRoot -RepoRoot $RepoRoot) `
-        "bin/$projectName/$configurationName`_$($Target.Framework)"
+    $propertyOutput = @(Invoke-DotNet @(
+        'msbuild', $projectPath, '--nologo', '-getProperty:TargetPath',
+        "-property:Configuration=$($Target.Configuration)",
+        "-property:TargetFramework=$($Target.Framework)",
+        '-property:UseSharedCompilation=false'
+    ))
+    $targetPaths = @($propertyOutput | ForEach-Object { ([string]$_).Trim() } | Where-Object {
+        $_ -and [System.IO.Path]::IsPathRooted($_) -and
+            [System.IO.Path]::GetExtension($_).Equals('.dll', [StringComparison]::OrdinalIgnoreCase)
+    })
+    if ($targetPaths.Count -ne 1) {
+        throw "MSBuild did not return one TargetPath for '$projectPath' ($($Target.Framework), $($Target.Configuration))."
+    }
+
+    $outputDirectory = [System.IO.Path]::GetDirectoryName($targetPaths[0])
     $candidates = @(
         (Join-Path $outputDirectory $projectName),
         (Join-Path $outputDirectory "$projectName.exe")

--- a/scripts/devops/testing/preparation.ps1
+++ b/scripts/devops/testing/preparation.ps1
@@ -7,7 +7,9 @@ function Get-AotExecutablePath {
         [string]$RepoRoot
     )
 
-    $publishDirectory = Join-Path $RepoRoot "src/devops/Rowles.LeanCorpus.Tests.AOTSmoke/bin/$($Target.Configuration)/$($Target.Framework)/$($Target.RuntimeIdentifier)/publish"
+    $configurationName = $Target.Configuration.ToLowerInvariant()
+    $publishDirectory = Join-Path (Get-ArtifactRoot -RepoRoot $RepoRoot) `
+        "publish/Rowles.LeanCorpus.Tests.AOTSmoke/$configurationName`_$($Target.Framework)_$($Target.RuntimeIdentifier)"
     $fileName = if ($Target.RuntimeIdentifier.StartsWith('win-', [StringComparison]::OrdinalIgnoreCase)) {
         'Rowles.LeanCorpus.Tests.AOTSmoke.exe'
     } else {
@@ -25,8 +27,9 @@ function Get-MtpExecutablePath {
 
     $projectPath = Resolve-TestProjectPath -Target $Target -RepoRoot $RepoRoot
     $projectName = [System.IO.Path]::GetFileNameWithoutExtension($projectPath)
-    $projectDirectory = [System.IO.Path]::GetDirectoryName($projectPath)
-    $outputDirectory = Join-Path $projectDirectory "bin/$($Target.Configuration)/$($Target.Framework)"
+    $configurationName = $Target.Configuration.ToLowerInvariant()
+    $outputDirectory = Join-Path (Get-ArtifactRoot -RepoRoot $RepoRoot) `
+        "bin/$projectName/$configurationName`_$($Target.Framework)"
     $candidates = @(
         (Join-Path $outputDirectory $projectName),
         (Join-Path $outputDirectory "$projectName.exe")

--- a/scripts/devops/testing/reports.ps1
+++ b/scripts/devops/testing/reports.ps1
@@ -121,7 +121,21 @@ function New-TestReportDocument {
             maximumDurationMs = [double]$Summary.MaximumDurationMs
             totalDurationMs = [double]$Summary.TotalDurationMs
             outcomeCounts = $Summary.OutcomeCounts
+            warnings = [int]$Summary.WarningCount
         }
+        telemetry = [ordered]@{
+            tests = [int]$Summary.TelemetrySummary.tests
+            activities = [int]$Summary.TelemetrySummary.activities
+            metrics = [int]$Summary.TelemetrySummary.metrics
+            swallowedExceptions = [int]$Summary.TelemetrySummary.swallowedExceptions
+            orphanedActivities = [int]$Summary.TelemetrySummary.orphanedActivities
+            summaryPaths = @($Summary.TelemetrySummary.summaryPaths | ForEach-Object {
+                Get-TestArtifactRelativePath -Context $Context -Path $_
+            })
+        }
+        attachmentPaths = @($Summary.AttachmentPaths | ForEach-Object {
+            Get-TestArtifactRelativePath -Context $Context -Path $_
+        })
         targetResults = @($Summary.TargetResults)
         tests = @($Summary.Tests | ForEach-Object { ConvertTo-TestReportTestDocument $_ })
         intermittentFailures = @($Summary.IntermittentFailures | ForEach-Object { ConvertTo-TestReportTestDocument $_ })
@@ -239,6 +253,15 @@ function New-TestMarkdownReport {
     }
     [void]$builder.AppendLine()
 
+    [void]$builder.AppendLine('## Telemetry')
+    [void]$builder.AppendLine()
+    [void]$builder.AppendLine("- Test summaries: $($Summary.TelemetrySummary.tests)")
+    [void]$builder.AppendLine("- Activities: $($Summary.TelemetrySummary.activities)")
+    [void]$builder.AppendLine("- Measurements: $($Summary.TelemetrySummary.metrics)")
+    [void]$builder.AppendLine("- Warnings: $($Summary.WarningCount)")
+    [void]$builder.AppendLine("- Orphaned activity observations: $($Summary.TelemetrySummary.orphanedActivities)")
+    [void]$builder.AppendLine()
+
     foreach ($section in @(
         @{ Title = 'Intermittent failures'; Items = @($Summary.IntermittentFailures); Property = 'Classification' },
         @{ Title = 'Always-failing tests'; Items = @($Summary.AlwaysFailingTests); Property = 'Classification' },
@@ -284,8 +307,18 @@ function New-TestMarkdownReport {
     [void]$builder.AppendLine('## Diagnostics and artefacts')
     [void]$builder.AppendLine()
     [void]$builder.AppendLine('- Run directory: `artifacts/test/runs/' + (ConvertTo-MarkdownCell $Context.RunId) + '`')
-    foreach ($path in @($Summary.DiagnosticArtifactPaths)) {
-        [void]$builder.AppendLine('- `' + (ConvertTo-MarkdownCell (Get-TestArtifactRelativePath -Context $Context -Path $path)) + '`')
+    $evidencePaths = @($Summary.DiagnosticArtifactPaths | ForEach-Object {
+        $relative = Get-TestArtifactRelativePath -Context $Context -Path $_
+        if ($relative -match '^(targets/[^/]+/\d+)/(telemetry|runtime)/') {
+            "$($Matches[1])/$($Matches[2])/"
+        } elseif ($relative -match '^(targets/[^/]+/\d+)/[^/]+/leancorpus-') {
+            "$($Matches[1])/attachments/"
+        } else {
+            $relative
+        }
+    } | Where-Object { $_ } | Sort-Object -Unique)
+    foreach ($path in $evidencePaths) {
+        [void]$builder.AppendLine('- `' + (ConvertTo-MarkdownCell $path) + '`')
     }
     if (@($Summary.InfrastructureErrors).Count -gt 0) {
         [void]$builder.AppendLine()
@@ -368,15 +401,15 @@ function Write-TestRunReports {
     $reportDocument = New-TestReportDocument -Context $Context -Summary $Summary
 
     try {
-        Write-AtomicJsonFile -Path (Join-Path $Context.RunDirectory 'summary.json') -Value $reportDocument
+        Write-AtomicJsonFile -Path (Join-Path $Context.RunDirectory 'report.json') -Value $reportDocument
     } catch {
-        [void]$errors.Add("summary.json: $($_.Exception.Message)")
+        [void]$errors.Add("report.json: $($_.Exception.Message)")
     }
 
     try {
-        Write-AtomicTextFile -Path (Join-Path $Context.RunDirectory 'summary.md') -Content (New-TestMarkdownReport -Context $Context -Summary $Summary)
+        Write-AtomicTextFile -Path (Join-Path $Context.RunDirectory 'report.md') -Content (New-TestMarkdownReport -Context $Context -Summary $Summary)
     } catch {
-        [void]$errors.Add("summary.md: $($_.Exception.Message)")
+        [void]$errors.Add("report.md: $($_.Exception.Message)")
     }
 
     try {
@@ -393,5 +426,5 @@ function Write-TestRunReports {
         throw "One or more test reports could not be written: $($errors -join '; ')"
     }
 
-    Write-Success "Report: $(Join-Path $Context.RunDirectory 'summary.md')"
+    Write-Success "Report: $(Join-Path $Context.RunDirectory 'report.md')"
 }

--- a/scripts/devops/testing/reports.ps1
+++ b/scripts/devops/testing/reports.ps1
@@ -121,7 +121,6 @@ function New-TestReportDocument {
             maximumDurationMs = [double]$Summary.MaximumDurationMs
             totalDurationMs = [double]$Summary.TotalDurationMs
             outcomeCounts = $Summary.OutcomeCounts
-            warnings = [int]$Summary.WarningCount
         }
         telemetry = [ordered]@{
             tests = [int]$Summary.TelemetrySummary.tests
@@ -258,7 +257,7 @@ function New-TestMarkdownReport {
     [void]$builder.AppendLine("- Test summaries: $($Summary.TelemetrySummary.tests)")
     [void]$builder.AppendLine("- Activities: $($Summary.TelemetrySummary.activities)")
     [void]$builder.AppendLine("- Measurements: $($Summary.TelemetrySummary.metrics)")
-    [void]$builder.AppendLine("- Warnings: $($Summary.WarningCount)")
+    [void]$builder.AppendLine("- Swallowed exceptions: $($Summary.TelemetrySummary.swallowedExceptions)")
     [void]$builder.AppendLine("- Orphaned activity observations: $($Summary.TelemetrySummary.orphanedActivities)")
     [void]$builder.AppendLine()
 

--- a/scripts/devops/testing/results.ps1
+++ b/scripts/devops/testing/results.ps1
@@ -320,6 +320,25 @@ function Get-NearestRankPercentile {
     return [double]$sorted[$rank - 1]
 }
 
+function Get-TestSummaryPropertySum {
+    param(
+        [object[]]$Items = @(),
+        [Parameter(Mandatory = $true)]
+        [string]$Property
+    )
+
+    if ($Items.Count -eq 0) {
+        return 0L
+    }
+
+    $measurement = $Items | Measure-Object -Property $Property -Sum
+    if ($null -eq $measurement -or $null -eq $measurement.Sum) {
+        return 0L
+    }
+
+    return [long]$measurement.Sum
+}
+
 function New-TestRunSummary {
     param(
         [Parameter(Mandatory = $true)]
@@ -503,13 +522,13 @@ function New-TestRunSummary {
         InfrastructureErrors = @($Context.InfrastructureErrors)
         DiagnosticArtifactPaths = $diagnosticPaths
         AttachmentPaths = $attachmentPaths
-        WarningCount = [int](@($telemetrySummaries | Measure-Object -Property swallowedExceptions -Sum).Sum)
+        WarningCount = [int](Get-TestSummaryPropertySum -Items $telemetrySummaries -Property swallowedExceptions)
         TelemetrySummary = [ordered]@{
             tests = $telemetrySummaries.Count
-            activities = [int](@($telemetrySummaries | Measure-Object -Property activityCount -Sum).Sum)
-            metrics = [int](@($telemetrySummaries | Measure-Object -Property metricCount -Sum).Sum)
-            swallowedExceptions = [int](@($telemetrySummaries | Measure-Object -Property swallowedExceptions -Sum).Sum)
-            orphanedActivities = [int](@($telemetrySummaries | Measure-Object -Property orphanedActivities -Sum).Sum)
+            activities = [int](Get-TestSummaryPropertySum -Items $telemetrySummaries -Property activityCount)
+            metrics = [int](Get-TestSummaryPropertySum -Items $telemetrySummaries -Property metricCount)
+            swallowedExceptions = [int](Get-TestSummaryPropertySum -Items $telemetrySummaries -Property swallowedExceptions)
+            orphanedActivities = [int](Get-TestSummaryPropertySum -Items $telemetrySummaries -Property orphanedActivities)
             summaryPaths = $telemetrySummaryPaths
         }
     }

--- a/scripts/devops/testing/results.ps1
+++ b/scripts/devops/testing/results.ps1
@@ -339,6 +339,27 @@ function Get-TestSummaryPropertySum {
     return [long]$measurement.Sum
 }
 
+function Get-TestObservationClassification {
+    param(
+        [object[]]$Observations,
+        [int]$ExpectedObservationCount
+    )
+
+    $observations = @($Observations)
+    $hasNonTerminalOutcome = @($observations | Where-Object {
+        $_.Outcome -notin @('Passed', 'Failed', 'Error', 'Timeout')
+    }).Count -gt 0
+    if ($observations.Count -lt $ExpectedObservationCount -or $hasNonTerminalOutcome) { return 'Incomplete' }
+
+    $failedCount = @($observations | Where-Object { $_.Outcome -in @('Failed', 'Error', 'Timeout') }).Count
+    $passedCount = @($observations | Where-Object { $_.Outcome -eq 'Passed' }).Count
+    if ($observations.Count -eq 1) { return $(if ($passedCount -eq 1) { 'Passed' } else { 'Failed' }) }
+    if ($failedCount -gt 0 -and $passedCount -gt 0) { return 'Intermittent failure' }
+    if ($failedCount -eq $observations.Count) { return 'Always fails' }
+    if ($passedCount -eq $observations.Count) { return 'Always passes' }
+    return 'Incomplete'
+}
+
 function New-TestRunSummary {
     param(
         [Parameter(Mandatory = $true)]
@@ -422,23 +443,9 @@ function New-TestRunSummary {
         } else {
             0
         }
-        $hasNonTerminalTestOutcome = @($observations | Where-Object {
-            $_.Outcome -notin @('Passed', 'Failed', 'Error', 'Timeout')
-        }).Count -gt 0
-        $isIncomplete = $observations.Count -lt $expected -or $hasNonTerminalTestOutcome
         $failedObservations = @($observations | Where-Object { $_.Outcome -in @('Failed', 'Error', 'Timeout') })
         $passedObservations = @($observations | Where-Object { $_.Outcome -eq 'Passed' })
-        $classification = if ($isIncomplete) {
-            'Incomplete'
-        } elseif ($failedObservations.Count -gt 0 -and $passedObservations.Count -gt 0) {
-            'Intermittent failure'
-        } elseif ($failedObservations.Count -eq $observations.Count) {
-            'Always fails'
-        } elseif ($passedObservations.Count -eq $observations.Count) {
-            'Always passes'
-        } else {
-            'Incomplete'
-        }
+        $classification = Get-TestObservationClassification -Observations $observations -ExpectedObservationCount $expected
         [void]$perTest.Add([pscustomobject]@{
             TargetKey = $observation.TargetKey
             Suite = $observation.Suite

--- a/scripts/devops/testing/results.ps1
+++ b/scripts/devops/testing/results.ps1
@@ -522,7 +522,6 @@ function New-TestRunSummary {
         InfrastructureErrors = @($Context.InfrastructureErrors)
         DiagnosticArtifactPaths = $diagnosticPaths
         AttachmentPaths = $attachmentPaths
-        WarningCount = [int](Get-TestSummaryPropertySum -Items $telemetrySummaries -Property swallowedExceptions)
         TelemetrySummary = [ordered]@{
             tests = $telemetrySummaries.Count
             activities = [int](Get-TestSummaryPropertySum -Items $telemetrySummaries -Property activityCount)

--- a/scripts/devops/testing/results.ps1
+++ b/scripts/devops/testing/results.ps1
@@ -281,7 +281,12 @@ function Get-ExecutionDiagnosticPaths {
     $diagnosticExtensions = @('.dmp', '.diag', '.nettrace', '.gcdump')
     $paths = [System.Collections.Generic.List[string]]::new()
     foreach ($file in @(Get-ChildItem -LiteralPath $ArtifactDirectory -File -Recurse -ErrorAction SilentlyContinue)) {
-        if ($file.Extension.ToLowerInvariant() -in $diagnosticExtensions) {
+        $relativePath = [System.IO.Path]::GetRelativePath($ArtifactDirectory, $file.FullName).Replace('\', '/')
+        if ($file.Extension.ToLowerInvariant() -in $diagnosticExtensions -or
+            $relativePath -eq 'results.ctrf.json' -or
+            $relativePath.StartsWith('telemetry/', [StringComparison]::OrdinalIgnoreCase) -or
+            $relativePath.StartsWith('runtime/', [StringComparison]::OrdinalIgnoreCase) -or
+            $file.Name.StartsWith('leancorpus-', [StringComparison]::OrdinalIgnoreCase)) {
             [void]$paths.Add($file.FullName)
         }
     }
@@ -446,6 +451,17 @@ function New-TestRunSummary {
     $failingIterations = @($executions | Where-Object { $_.Outcome -ne 'Passed' } |
         ForEach-Object { [int]$_.Iteration } | Sort-Object -Unique)
     $diagnosticPaths = @($executions | ForEach-Object { @($_.DiagnosticPaths) } | Where-Object { $_ })
+    $telemetrySummaryPaths = @($diagnosticPaths | Where-Object {
+        $_.Replace('\', '/') -match '/telemetry/tests/[^/]+/summary\.json$'
+    })
+    $telemetrySummaries = @($telemetrySummaryPaths | ForEach-Object {
+        try { Get-Content -LiteralPath $_ -Raw | ConvertFrom-Json } catch { $null }
+    } | Where-Object { $null -ne $_ })
+    $attachmentPaths = @($diagnosticPaths | Where-Object {
+        $normalised = $_.Replace('\', '/')
+        [System.IO.Path]::GetFileName($_).StartsWith('leancorpus-', [StringComparison]::OrdinalIgnoreCase) -and
+            $normalised -notmatch '/telemetry/tests/'
+    })
     $totalDuration = if ($Context.EndTimeUtc) {
         ($Context.EndTimeUtc - $Context.StartTimeUtc).TotalMilliseconds
     } else {
@@ -486,5 +502,15 @@ function New-TestRunSummary {
         IncompleteTargets = @($targetDocuments | Where-Object { $_.outcome -eq 'Incomplete' })
         InfrastructureErrors = @($Context.InfrastructureErrors)
         DiagnosticArtifactPaths = $diagnosticPaths
+        AttachmentPaths = $attachmentPaths
+        WarningCount = [int](@($telemetrySummaries | Measure-Object -Property swallowedExceptions -Sum).Sum)
+        TelemetrySummary = [ordered]@{
+            tests = $telemetrySummaries.Count
+            activities = [int](@($telemetrySummaries | Measure-Object -Property activityCount -Sum).Sum)
+            metrics = [int](@($telemetrySummaries | Measure-Object -Property metricCount -Sum).Sum)
+            swallowedExceptions = [int](@($telemetrySummaries | Measure-Object -Property swallowedExceptions -Sum).Sum)
+            orphanedActivities = [int](@($telemetrySummaries | Measure-Object -Property orphanedActivities -Sum).Sum)
+            summaryPaths = $telemetrySummaryPaths
+        }
     }
 }

--- a/scripts/devops/testing/runner.ps1
+++ b/scripts/devops/testing/runner.ps1
@@ -232,7 +232,7 @@ function Invoke-TestPipeline {
         Write-Host "  Failed runs:   $($summary.FailingIterations -join ', ')"
     }
     if ($context.ArtifactsEnabled) {
-        Write-Host "  Report:        $(Join-Path $context.RunDirectory 'summary.md')"
+        Write-Host "  Report:        $(Join-Path $context.RunDirectory 'report.md')"
     }
 
     if ($null -ne $pipelineError -or $reportError -or $context.ReportErrors.Count -gt 0 -or -not $summary.Succeeded) {

--- a/scripts/devops/testing/runner.ps1
+++ b/scripts/devops/testing/runner.ps1
@@ -72,11 +72,12 @@ function Invoke-TestPipeline {
         [Parameter(Mandatory = $true)]
         [string]$CommandLine,
         [string]$DisplayName = 'Test run',
+        [string]$RunId = '',
         [string]$RepoRoot = (Get-RepoRoot)
     )
 
     $context = New-TestRunContext -Options $Options -Targets $Targets `
-        -CommandLine $CommandLine -RepoRoot $RepoRoot
+        -CommandLine $CommandLine -RunId $RunId -RepoRoot $RepoRoot
     $summary = $null
     $pipelineError = $null
     $reportError = $false

--- a/scripts/devops/testing/runner.ps1
+++ b/scripts/devops/testing/runner.ps1
@@ -202,15 +202,28 @@ function Invoke-TestPipeline {
                 }
             }
             try {
-                if ($null -ne $summary) {
-                    Update-TestRunManifest -Context $context -Summary $summary
-                }
-                $finalStatus = if ($null -eq $pipelineError) { 'Completed' } else { 'Failed' }
+                $finalStatus = if ($null -eq $pipelineError -and
+                    -not $reportError -and
+                    $context.ReportErrors.Count -eq 0 -and
+                    $null -ne $summary -and
+                    [bool]$summary.Succeeded) { 'Passed' } else { 'Failed' }
+                Update-TestRunManifest -Context $context -Summary $summary -Status $finalStatus
                 Write-TestRunCheckpoint -Context $context -Status $finalStatus
             } catch {
                 $reportError = $true
                 [void]$context.ReportErrors.Add("Final artefact update failed: $($_.Exception.Message)")
                 Write-Failure "Final artefact update failed: $($_.Exception.Message)"
+                try {
+                    Complete-ArtifactRun -RunDirectory $context.RunDirectory -Status Failed `
+                        -AdditionalValues @{ error = $_.Exception.Message }
+                } catch {
+                    [void]$context.ReportErrors.Add("Failed run finalisation failed: $($_.Exception.Message)")
+                }
+                try {
+                    Write-TestRunCheckpoint -Context $context -Status 'Failed'
+                } catch {
+                    [void]$context.ReportErrors.Add("Failed checkpoint update failed: $($_.Exception.Message)")
+                }
             }
         }
     }

--- a/scripts/devops/testing/testconfig.json
+++ b/scripts/devops/testing/testconfig.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://xunit.net/schema/v4.0/xunit.runner.schema.json",
+  "diagnosticMessages": true,
+  "failSkips": false,
+  "failWarns": false,
+  "longRunningTestSeconds": 30,
+  "maxParallelThreads": "1x",
+  "parallelAlgorithm": "conservative",
+  "parallelMode": "collections",
+  "preEnumerateTheories": true,
+  "showLiveOutput": false,
+  "shutdownForegroundThreadWaitSeconds": 10
+}

--- a/scripts/devops/validation/artifacts-smoke.ps1
+++ b/scripts/devops/validation/artifacts-smoke.ps1
@@ -1,0 +1,130 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$temporaryRoot = Join-Path ([System.IO.Path]::GetTempPath()) "leancorpus-artifacts-smoke-$([Guid]::NewGuid().ToString('N'))"
+$modulePath = Join-Path $PSScriptRoot '../DevOps.psm1'
+$generatorPath = Join-Path $PSScriptRoot '../../benchmarks/generate-docs.ps1'
+
+try {
+    [void][System.IO.Directory]::CreateDirectory($temporaryRoot)
+    $devopsModule = Import-Module -Name $modulePath -Force -PassThru
+
+    & $devopsModule {
+        param(
+            [string]$Root,
+            [string]$Generator
+        )
+
+        function Assert-Smoke {
+            param(
+                [bool]$Condition,
+                [Parameter(Mandatory = $true)]
+                [string]$Message
+            )
+
+            if (-not $Condition) {
+                throw "Artefact smoke assertion failed: $Message"
+            }
+        }
+
+        function Write-SmokeMarker {
+            param([string]$Path)
+
+            $parent = Split-Path -Parent $Path
+            [void][System.IO.Directory]::CreateDirectory($parent)
+            [System.IO.File]::WriteAllText($Path, 'smoke')
+        }
+
+        # A. Common run lifecycle.
+        $run = New-ArtifactRun -Kind test -Framework net10.0 -Configuration Release `
+            -CommandLine 'artifacts-smoke' -RepoRoot $Root -RunId 'lifecycle'
+        $manifestPath = Join-Path $run.RunDirectory 'run.json'
+        Assert-Smoke (Test-Path $manifestPath -PathType Leaf) 'run.json was not created.'
+        $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+        Assert-Smoke ($manifest.status -eq 'Running') 'new run was not Running.'
+        Assert-Smoke ('commit' -in @($manifest.PSObject.Properties.Name)) 'common commit provenance is missing.'
+        Update-ArtifactRunManifest -RunDirectory $run.RunDirectory -Values @{ customField = 'retained' }
+        Complete-ArtifactRun -RunDirectory $run.RunDirectory -Status Passed
+        $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+        Assert-Smoke ($manifest.status -eq 'Passed') 'completed run was not Passed.'
+        Assert-Smoke ([bool]$manifest.completedAtUtc) 'completion timestamp is missing.'
+        Assert-Smoke ($manifest.customField -eq 'retained') 'custom manifest field was lost.'
+        $latestRun = Get-LatestSuccessfulArtifactRun -Kind test -RepoRoot $Root
+        Assert-Smoke ($null -ne $latestRun -and $latestRun.RunDirectory -eq $run.RunDirectory) 'latest successful run discovery failed.'
+
+        # B. Clean containment.
+        $artifactRoot = Get-ArtifactRoot -RepoRoot $Root
+        $ownedFile = Join-Path $artifactRoot 'test/delete-me.txt'
+        $outsideFile = Join-Path $Root 'outside/must-survive.txt'
+        Write-SmokeMarker $ownedFile
+        Write-SmokeMarker $outsideFile
+        Invoke-ArtifactClean -Target test -RepoRoot $Root
+        Assert-Smoke (-not (Test-Path $ownedFile)) 'owned test artefact was not removed.'
+        Assert-Smoke (Test-Path $outsideFile) 'outside file was removed by owned clean.'
+        $refused = $false
+        try {
+            Remove-OwnedArtifactPath -Path (Split-Path -Parent $outsideFile) -ArtifactRoot $artifactRoot
+        } catch {
+            $refused = $true
+        }
+        Assert-Smoke $refused 'clean accepted a path outside the artefact root.'
+
+        # C. Default clean preservation.
+        foreach ($relative in @(
+            'test/marker.txt',
+            'coverage/marker.txt',
+            'docs/marker.txt',
+            'diagnostics/marker.txt',
+            'temp/marker.txt',
+            'benchmark/runs/marker.txt',
+            'benchmark/cache/marker.txt',
+            'package/marker.txt'
+        )) {
+            Write-SmokeMarker (Join-Path $artifactRoot $relative)
+        }
+        Invoke-ArtifactClean -Target default -RepoRoot $Root
+        foreach ($relative in @('test', 'coverage', 'docs', 'diagnostics', 'temp')) {
+            Assert-Smoke (-not (Test-Path (Join-Path $artifactRoot $relative))) "default clean retained $relative."
+        }
+        foreach ($relative in @('benchmark/runs', 'benchmark/cache', 'package')) {
+            Assert-Smoke (Test-Path (Join-Path $artifactRoot $relative)) "default clean removed $relative."
+        }
+
+        # D. Benchmark report schema coexistence.
+        $benchmarkRoot = Join-Path $artifactRoot 'benchmark/runs/example'
+        $coreRoot = Join-Path $benchmarkRoot 'core'
+        $suiteRoot = Join-Path $coreRoot 'query'
+        [void][System.IO.Directory]::CreateDirectory($suiteRoot)
+        Write-AtomicJsonFile -Path (Join-Path $benchmarkRoot 'run-report.json') -Value @{
+            schemaVersion = 1
+            status = 'Passed'
+            projects = @()
+        }
+        Write-AtomicJsonFile -Path (Join-Path $coreRoot 'report.json') -Value @{
+            totalBenchmarkCount = 1
+            generatedAtUtc = [DateTime]::UtcNow.ToString('O')
+            commitHash = 'smoke'
+            dotnetVersion = 'smoke'
+            provenance = @{ machineName = 'smoke'; effectiveDocCount = 1 }
+            suites = @(@{ suiteName = 'query' })
+        }
+        @(
+            '| Method | Mean |',
+            '| --- | --- |',
+            '| Example | 1 ns |'
+        ) | Set-Content -LiteralPath (Join-Path $suiteRoot 'example-report-github.md') -Encoding UTF8
+        $outputRoot = Join-Path $Root 'generated-benchmark-docs'
+        & $Generator -BenchDir (Join-Path $artifactRoot 'benchmark/runs') -OutputDir $outputRoot
+        Assert-Smoke (Test-Path (Join-Path $outputRoot 'query.md')) 'Core benchmark page was not generated.'
+
+        Write-Host 'Artefact infrastructure smoke validation passed.'
+    } $temporaryRoot $generatorPath
+    exit 0
+} catch {
+    Write-Error "Artefact infrastructure smoke validation failed: $($_.Exception.Message)"
+    exit 1
+} finally {
+    if (Test-Path $temporaryRoot) {
+        Remove-Item -LiteralPath $temporaryRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/scripts/devops/validation/artifacts-smoke.ps1
+++ b/scripts/devops/validation/artifacts-smoke.ps1
@@ -12,7 +12,8 @@ try {
     & $devopsModule {
         param(
             [string]$Root,
-            [string]$Generator
+            [string]$Generator,
+            [string]$RepositoryRoot
         )
 
         function Assert-Smoke {
@@ -68,6 +69,18 @@ try {
             $refused = $true
         }
         Assert-Smoke $refused 'clean accepted a path outside the artefact root.'
+        if (-not $IsWindows) {
+            $caseDifferentPath = Join-Path $Root 'ARTIFACTS-case-test'
+            Write-SmokeMarker (Join-Path $caseDifferentPath 'must-survive.txt')
+            $caseRefused = $false
+            try {
+                Remove-OwnedArtifactPath -Path $caseDifferentPath -ArtifactRoot $artifactRoot
+            } catch {
+                $caseRefused = $true
+            }
+            Assert-Smoke $caseRefused 'Unix clean accepted a case-different sibling.'
+            Assert-Smoke (Test-Path $caseDifferentPath) 'Unix clean removed a case-different sibling.'
+        }
 
         # C. Default clean preservation.
         foreach ($relative in @(
@@ -90,7 +103,7 @@ try {
             Assert-Smoke (Test-Path (Join-Path $artifactRoot $relative)) "default clean removed $relative."
         }
 
-        # D. Benchmark report schema coexistence.
+        # D. Benchmark evidence selection and overlay behaviour.
         $benchmarkRoot = Join-Path $artifactRoot 'benchmark/runs/example'
         $coreRoot = Join-Path $benchmarkRoot 'core'
         $suiteRoot = Join-Path $coreRoot 'query'
@@ -98,7 +111,12 @@ try {
         Write-AtomicJsonFile -Path (Join-Path $benchmarkRoot 'run-report.json') -Value @{
             schemaVersion = 1
             status = 'Passed'
-            projects = @()
+            projects = @(@{ project = 'core'; status = 'Passed'; exitCode = 0; path = 'core' })
+        }
+        Write-AtomicJsonFile -Path (Join-Path $benchmarkRoot 'run.json') -Value @{
+            runId = 'example'
+            status = 'Passed'
+            completedAtUtc = '2026-01-01T00:00:00Z'
         }
         Write-AtomicJsonFile -Path (Join-Path $coreRoot 'report.json') -Value @{
             totalBenchmarkCount = 1
@@ -106,19 +124,82 @@ try {
             commitHash = 'smoke'
             dotnetVersion = 'smoke'
             provenance = @{ machineName = 'smoke'; effectiveDocCount = 1 }
-            suites = @(@{ suiteName = 'query' })
+            suites = @(@{ suiteName = 'query'; failedBenchmarkCount = 0; missingBenchmarkCount = 0 })
         }
         @(
             '| Method | Mean |',
             '| --- | --- |',
             '| Example | 1 ns |'
         ) | Set-Content -LiteralPath (Join-Path $suiteRoot 'example-report-github.md') -Encoding UTF8
+        $olderTextRoot = Join-Path $artifactRoot 'benchmark/runs/text-older'
+        $olderTextResults = Join-Path $olderTextRoot 'text/results'
+        [void][System.IO.Directory]::CreateDirectory($olderTextResults)
+        Write-AtomicJsonFile -Path (Join-Path $olderTextRoot 'run.json') -Value @{
+            runId = 'text-older'; status = 'Passed'; completedAtUtc = '2026-01-02T00:00:00Z'
+        }
+        Write-AtomicJsonFile -Path (Join-Path $olderTextRoot 'run-report.json') -Value @{
+            projects = @(@{ project = 'text'; status = 'Passed'; exitCode = 0; path = 'text' })
+        }
+        @('| Method | Mean |', '| --- | --- |', '| OLDER-PASSED | 1 ns |') |
+            Set-Content -LiteralPath (Join-Path $olderTextResults 'text-report-github.md') -Encoding UTF8
+
+        $newerTextRoot = Join-Path $artifactRoot 'benchmark/runs/text-newer'
+        $newerTextResults = Join-Path $newerTextRoot 'text/results'
+        [void][System.IO.Directory]::CreateDirectory($newerTextResults)
+        Write-AtomicJsonFile -Path (Join-Path $newerTextRoot 'run.json') -Value @{
+            runId = 'text-newer'; status = 'Failed'; completedAtUtc = '2026-01-03T00:00:00Z'
+        }
+        Write-AtomicJsonFile -Path (Join-Path $newerTextRoot 'run-report.json') -Value @{
+            projects = @(@{ project = 'text'; status = 'Failed'; exitCode = 1; path = 'text' })
+        }
+        @('| Method | Mean |', '| --- | --- |', '| NEWER-FAILED | 1 ns |') |
+            Set-Content -LiteralPath (Join-Path $newerTextResults 'text-report-github.md') -Encoding UTF8
+
+        $compressionRoot = Join-Path $artifactRoot 'benchmark/runs/compression-only'
+        $compressionResults = Join-Path $compressionRoot 'compression/results'
+        [void][System.IO.Directory]::CreateDirectory($compressionResults)
+        Write-AtomicJsonFile -Path (Join-Path $compressionRoot 'run.json') -Value @{
+            runId = 'compression-only'; status = 'Passed'; completedAtUtc = '2026-01-02T12:00:00Z'
+        }
+        Write-AtomicJsonFile -Path (Join-Path $compressionRoot 'run-report.json') -Value @{
+            projects = @(@{ project = 'compression'; status = 'Passed'; exitCode = 0; path = 'compression' })
+        }
+        @('| Method | Mean |', '| --- | --- |', '| COMPRESSION-PASSED | 1 ns |') |
+            Set-Content -LiteralPath (Join-Path $compressionResults 'compression-report-github.md') -Encoding UTF8
+
+        $publishedRoot = Join-Path $Root 'published-benchmark-docs'
+        [void][System.IO.Directory]::CreateDirectory($publishedRoot)
+        Set-Content -LiteralPath (Join-Path $publishedRoot 'unrelated.md') -Value 'PUBLISHED-BASELINE' -Encoding UTF8
         $outputRoot = Join-Path $Root 'generated-benchmark-docs'
-        & $Generator -BenchDir (Join-Path $artifactRoot 'benchmark/runs') -OutputDir $outputRoot
+        & $Generator -BenchDir (Join-Path $artifactRoot 'benchmark/runs') -OutputDir $outputRoot -PublishedDir $publishedRoot
         Assert-Smoke (Test-Path (Join-Path $outputRoot 'query.md')) 'Core benchmark page was not generated.'
+        $textPage = Get-Content -LiteralPath (Join-Path $outputRoot 'text.md') -Raw
+        Assert-Smoke ($textPage.Contains('OLDER-PASSED')) 'older passed text evidence was not selected.'
+        Assert-Smoke (-not $textPage.Contains('NEWER-FAILED')) 'newer failed text evidence replaced passed evidence.'
+        Assert-Smoke ((Get-Content -LiteralPath (Join-Path $outputRoot 'compression.md') -Raw).Contains('COMPRESSION-PASSED')) 'compression-only evidence was not generated.'
+        Assert-Smoke (Test-Path (Join-Path $outputRoot 'unrelated.md')) 'published baseline page was erased.'
+
+        # E. One-shot and repeated test classifications.
+        $pass = [pscustomobject]@{ Outcome = 'Passed' }
+        $fail = [pscustomobject]@{ Outcome = 'Failed' }
+        Assert-Smoke ((Get-TestObservationClassification @($pass) 1) -eq 'Passed') 'one pass was not classified Passed.'
+        Assert-Smoke ((Get-TestObservationClassification @($fail) 1) -eq 'Failed') 'one failure was not classified Failed.'
+        Assert-Smoke ((Get-TestObservationClassification @($pass, $pass) 2) -eq 'Always passes') 'repeated passes were misclassified.'
+        Assert-Smoke ((Get-TestObservationClassification @($fail, $fail) 2) -eq 'Always fails') 'repeated failures were misclassified.'
+        Assert-Smoke ((Get-TestObservationClassification @($pass, $fail) 2) -eq 'Intermittent failure') 'mixed repeats were misclassified.'
+
+        # F. Windows stress-test timeout and cleanup evidence contract.
+        $stressTestPath = Join-Path $RepositoryRoot 'src/devops/Rowles.LeanCorpus.Tests.Core/Index/Integration/CommitSearcherRaceReproTests.cs'
+        $stressTest = Get-Content -LiteralPath $stressTestPath -Raw
+        Assert-Smoke ($stressTest.Contains('Timeout = 120_000')) 'stress-test timeout is not 120 seconds.'
+        Assert-Smoke ($stressTest.Contains('const int iterations = 120')) 'stress iterations changed.'
+        Assert-Smoke ($stressTest.Contains('const int pinnedGenerations = 8')) 'pinned generation count changed.'
+        foreach ($cleanupStage in @('held searchers released', 'SearcherManager.Dispose', 'IndexWriter.Dispose', 'MMapDirectory.Dispose')) {
+            Assert-Smoke ($stressTest.Contains($cleanupStage)) "stress cleanup timing is missing for $cleanupStage."
+        }
 
         Write-Host 'Artefact infrastructure smoke validation passed.'
-    } $temporaryRoot $generatorPath
+    } $temporaryRoot $generatorPath (Resolve-Path (Join-Path $PSScriptRoot '../../..'))
     exit 0
 } catch {
     Write-Error "Artefact infrastructure smoke validation failed: $($_.Exception.Message)"

--- a/src/devops/CONTRIBUTING.md
+++ b/src/devops/CONTRIBUTING.md
@@ -162,6 +162,7 @@ Choose the destination by responsibility:
 | Small reusable helper | `scripts/devops/common/` |
 | Declarative suites, mappings or strategies | `scripts/devops/config/` |
 | Larger reusable subsystem | `scripts/devops/support/` |
+| Artefact paths, runs and cleaning | `scripts/devops/artifacts/` |
 
 For a new top-level command:
 
@@ -190,6 +191,13 @@ checkpoint `state.json` after each target under
 `artifacts/test/runs/<run-id>/`. Missing or malformed MTP TRX data must remain
 an incomplete result, never a pass. Keep report generation in the common
 finalisation path so a failed target still leaves usable evidence.
+
+Use `-Profile unit` for test-case parallelisation, `-Profile integration` for
+the collection-parallel default, and `-Profile stress` only for deliberate
+contention. `-Diagnostics` and `-Flaky` stream LeanCorpus activities, meters and
+execution-scoped runtime evidence. Explicit tests remain excluded unless
+`-Explicit` or `-ExplicitOnly` is selected. Do not add retries to core,
+filesystem, concurrency, codec or indexing tests.
 
 Useful local checks include:
 

--- a/src/devops/README.md
+++ b/src/devops/README.md
@@ -58,8 +58,9 @@ or Native AOT process:
 
 Repeated, flaky, diagnostic and CI runs write one run directory under
 `artifacts/test/runs/<run-id>/`. It contains the selected targets, environment,
-stdout and stderr, MTP TRX files where supported, checkpoint state and the
-`summary.md`, `summary.json` and `timings.csv` reports. A failed test does not
+stdout and stderr, MTP TRX and CTRF files where supported, checkpoint state and
+the `report.md`, `report.json` and `timings.csv` reports. Diagnostic runs also
+stream per-test activities and metrics, plus execution-scoped runtime data. A failed test does not
 stop later repetitions unless `--fail-fast` is selected. `--flaky` is a preset
 for 30 repetitions unless `--count` supplies another value.
 
@@ -108,7 +109,7 @@ explicitly selected .NET process, use the standard diagnostic tools:
 ```
 
 Trace, GC dump, dump and capture output is written under
-`artifacts/diagnostics/<run-id>/`. Dumps can contain sensitive application
+`artifacts/diagnostics/runs/<run-id>/`. Dumps can contain sensitive application
 memory. Pass tool-specific options after `--` where the command supports it.
 
 ## Run affected tests
@@ -141,7 +142,8 @@ The AOT route publishes and runs a smoke executable for both supported framework
 ./devops coverage -Clean -GenerateReport
 ```
 
-Raw output is written under `coverage-results/`. Generated HTML is written under `docs/coverage/`.
+Each invocation writes raw data and an optional HTML report under
+`artifacts/coverage/runs/<run-id>/`.
 
 Coverage proves that code executed. It does not prove that the assertions or oracle were useful.
 
@@ -181,7 +183,10 @@ Skip expensive generated inputs when they are outside the documentation change:
 
 Serve the site locally with `./devops docs serve`.
 
-The docs command copies selected repository READMEs and contribution guides into the ignored `docs/.generated` staging tree before DocFX runs. Edit the canonical repository file, not the generated site copy.
+The docs command stages selected repository READMEs and contribution guides under
+`artifacts/docs/generated/repository/` before DocFX runs. Edit the canonical
+repository file, not the generated site copy. API metadata, coverage pages and
+the site are also written beneath `artifacts/docs/`.
 
 ## Project map
 
@@ -202,6 +207,7 @@ The docs command copies selected repository READMEs and contribution guides into
 `Tests.Shared` is infrastructure, not a runnable suite.
 
 > [!WARNING]
-> Do not edit `bin`, `obj`, BenchmarkDotNet artefacts, `coverage-results` or generated documentation manually. Change their source or generator.
+> Do not edit generated content under `artifacts/` manually. Change its source,
+> configuration or generator.
 
 To add tests or tooling, continue with [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/src/devops/Rowles.LeanCorpus.Benchmarks.Compression/Program.cs
+++ b/src/devops/Rowles.LeanCorpus.Benchmarks.Compression/Program.cs
@@ -1,19 +1,36 @@
 ﻿using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
 using Rowles.LeanCorpus.Benchmarks.Compression;
 using Rowles.LeanCorpus.Compression.LZ4;
 using Rowles.LeanCorpus.Compression.Snappy;
 using Rowles.LeanCorpus.Compression.Zstandard;
 
-// Register extension codecs in the parent process so the Ratio column can compress
-// payloads for ratio computation during report generation. Child processes receive
-// their own registrations via [GlobalSetup] in CompressionBenchmarks.
-Lz4Compression.Register();
-SnappyCompression.Register();
-ZstandardCompression.Register();
+namespace Rowles.LeanCorpus.Benchmarks.Compression;
 
-string artifactsPath = Environment.GetEnvironmentVariable("LEANCORPUS_ARTIFACT_DIR")
-    ?? Path.Combine(Directory.GetCurrentDirectory(), "artifacts", "benchmark", "runs", "direct", "compression");
-Directory.CreateDirectory(artifactsPath);
-var config = DefaultConfig.Instance.WithArtifactsPath(Path.Combine(artifactsPath, "_runner"));
-BenchmarkRunner.Run<CompressionBenchmarks>(config, args);
+internal static class Program
+{
+    public static int Main(string[] args)
+    {
+        // Register extension codecs in the parent process so the Ratio column can compress
+        // payloads for ratio computation during report generation. Child processes receive
+        // their own registrations via [GlobalSetup] in CompressionBenchmarks.
+        Lz4Compression.Register();
+        SnappyCompression.Register();
+        ZstandardCompression.Register();
+
+        var artifactsPath = Environment.GetEnvironmentVariable("LEANCORPUS_ARTIFACT_DIR")
+            ?? Path.Combine(Directory.GetCurrentDirectory(), "artifacts", "benchmark", "runs", "direct", "compression");
+        Directory.CreateDirectory(artifactsPath);
+        var config = DefaultConfig.Instance.WithArtifactsPath(Path.Combine(artifactsPath, "_runner"));
+        var summary = BenchmarkRunner.Run<CompressionBenchmarks>(config, args);
+        return HasInvalidResults(summary) ? 1 : 0;
+    }
+
+    private static bool HasInvalidResults(Summary summary)
+    {
+        return summary.HasCriticalValidationErrors ||
+            !summary.Reports.Any() ||
+            summary.Reports.Any(report => report.ResultStatistics is null);
+    }
+}

--- a/src/devops/Rowles.LeanCorpus.Benchmarks.Compression/Program.cs
+++ b/src/devops/Rowles.LeanCorpus.Benchmarks.Compression/Program.cs
@@ -1,4 +1,5 @@
-﻿using BenchmarkDotNet.Running;
+﻿using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Running;
 using Rowles.LeanCorpus.Benchmarks.Compression;
 using Rowles.LeanCorpus.Compression.LZ4;
 using Rowles.LeanCorpus.Compression.Snappy;
@@ -11,4 +12,8 @@ Lz4Compression.Register();
 SnappyCompression.Register();
 ZstandardCompression.Register();
 
-BenchmarkRunner.Run<CompressionBenchmarks>(null, args);
+string artifactsPath = Environment.GetEnvironmentVariable("LEANCORPUS_ARTIFACT_DIR")
+    ?? Path.Combine(Directory.GetCurrentDirectory(), "artifacts", "benchmark", "runs", "direct", "compression");
+Directory.CreateDirectory(artifactsPath);
+var config = DefaultConfig.Instance.WithArtifactsPath(Path.Combine(artifactsPath, "_runner"));
+BenchmarkRunner.Run<CompressionBenchmarks>(config, args);

--- a/src/devops/Rowles.LeanCorpus.Benchmarks.Compression/Program.cs
+++ b/src/devops/Rowles.LeanCorpus.Benchmarks.Compression/Program.cs
@@ -20,11 +20,26 @@ internal static class Program
         ZstandardCompression.Register();
 
         var artifactsPath = Environment.GetEnvironmentVariable("LEANCORPUS_ARTIFACT_DIR")
-            ?? Path.Combine(Directory.GetCurrentDirectory(), "artifacts", "benchmark", "runs", "direct", "compression");
+            ?? Path.Combine(FindRepositoryRoot(), "artifacts", "benchmark", "runs", "direct", "compression");
         Directory.CreateDirectory(artifactsPath);
         var config = DefaultConfig.Instance.WithArtifactsPath(Path.Combine(artifactsPath, "_runner"));
         var summary = BenchmarkRunner.Run<CompressionBenchmarks>(config, args);
         return HasInvalidResults(summary) ? 1 : 0;
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        foreach (string startPath in new[] { Directory.GetCurrentDirectory(), AppContext.BaseDirectory })
+        {
+            for (DirectoryInfo? directory = new(startPath); directory is not null; directory = directory.Parent)
+            {
+                if (File.Exists(Path.Combine(directory.FullName, "Rowles.LeanCorpus.slnx")))
+                    return directory.FullName;
+            }
+        }
+
+        throw new InvalidOperationException(
+            "LeanCorpus repository root could not be found. Run this benchmark through ./devops benchmark or from inside the repository.");
     }
 
     private static bool HasInvalidResults(Summary summary)

--- a/src/devops/Rowles.LeanCorpus.Benchmarks/Infrastructure/BenchmarkHelpers.cs
+++ b/src/devops/Rowles.LeanCorpus.Benchmarks/Infrastructure/BenchmarkHelpers.cs
@@ -8,7 +8,7 @@ namespace Rowles.LeanCorpus.Benchmarks;
 public static class BenchmarkHelpers
 {
     /// <summary>
-    /// Root directory for all benchmark temp files. Uses <c>bench/tmp</c> under the
+    /// Root directory for all benchmark temp files. Uses <c>artifacts/temp/benchmark</c> under the
     /// repository root (half-TB NVMe) instead of the 12 GB tmpfs RAM disk.
     /// </summary>
     public static string TempRoot { get; } = ResolveTempRoot();
@@ -44,7 +44,7 @@ public static class BenchmarkHelpers
     {
         // Walk up from the benchmark assembly location until we find the
         // repository root (marked by Rowles.LeanCorpus.slnx), then anchor
-        // bench/tmp there. Uses the assembly path rather than the current
+        // artifacts/temp/benchmark there. Uses the assembly path rather than the current
         // directory so it works regardless of how BenchmarkDotNet sets the cwd.
         var current = new DirectoryInfo(AppContext.BaseDirectory);
 
@@ -52,7 +52,7 @@ public static class BenchmarkHelpers
         {
             if (File.Exists(Path.Combine(current.FullName, "Rowles.LeanCorpus.slnx")))
             {
-                var root = Path.Combine(current.FullName, "bench", "tmp");
+                var root = Path.Combine(current.FullName, "artifacts", "temp", "benchmark");
                 Directory.CreateDirectory(root);
                 return root;
             }
@@ -61,7 +61,7 @@ public static class BenchmarkHelpers
         }
 
         // Fallback: use the current directory (shouldn't happen in practice).
-        var fallback = Path.Combine(Directory.GetCurrentDirectory(), "bench", "tmp");
+        var fallback = Path.Combine(Directory.GetCurrentDirectory(), "artifacts", "temp", "benchmark");
         Directory.CreateDirectory(fallback);
         return fallback;
     }

--- a/src/devops/Rowles.LeanCorpus.Benchmarks/Infrastructure/RealDataPool.cs
+++ b/src/devops/Rowles.LeanCorpus.Benchmarks/Infrastructure/RealDataPool.cs
@@ -6,7 +6,7 @@ namespace Rowles.LeanCorpus.Benchmarks;
 
 /// <summary>
 /// Provides a unified pool of real-world document bodies sourced from
-/// bench/data/ (Gutenberg ebooks, 20 Newsgroups, Reuters-21578).
+/// artifacts/benchmark/cache/data/ (Gutenberg ebooks, 20 Newsgroups, Reuters-21578).
 /// Falls back to synthetic content when no real data is present.
 /// </summary>
 /// <remarks>
@@ -57,12 +57,12 @@ internal static class RealDataPool
     private static LoadedDataSet LoadAll()
     {
         var root = GutenbergDataLoader.FindRepositoryRoot();
-        var benchDir = Path.Combine(root, "bench", "data");
+        var benchDir = Path.Combine(root, "artifacts", "benchmark", "cache", "data");
 
         if (!Directory.Exists(benchDir))
         {
             Console.Error.WriteLine(
-                $"[RealDataPool] bench/data not found at '{benchDir}'. " +
+                $"[RealDataPool] benchmark data cache not found at '{benchDir}'. " +
                 "Run the download scripts first. Falling back to synthetic data.");
             return new LoadedDataSet
             {
@@ -89,7 +89,7 @@ internal static class RealDataPool
         if (bodies.Count == 0)
         {
             Console.Error.WriteLine(
-                "[RealDataPool] No documents loaded from bench/data. " +
+                "[RealDataPool] No documents loaded from the benchmark data cache. " +
                 "Run the download scripts first. Falling back to synthetic data.");
             return new LoadedDataSet
             {
@@ -297,7 +297,7 @@ internal static class RealDataPool
         }
     }
 
-    /// <summary>Synthetic fallback used when bench/data is absent or empty.</summary>
+    /// <summary>Synthetic fallback used when the benchmark data cache is absent or empty.</summary>
     private static string[] BuildSynthetic(int count)
     {
         var topics  = new[] { "government", "economics", "politics", "science", "technology" };

--- a/src/devops/Rowles.LeanCorpus.Benchmarks/Program.cs
+++ b/src/devops/Rowles.LeanCorpus.Benchmarks/Program.cs
@@ -46,11 +46,12 @@ internal static class Program
         var repoRoot = FindRepositoryRoot();
         var now = DateTimeOffset.UtcNow;
 
-        var machineDir = Path.Combine(repoRoot, "bench", Environment.MachineName);
-        var runDir = Path.Combine(
-            machineDir,
-            now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
-            now.ToString("HH-mm", CultureInfo.InvariantCulture));
+        var suppliedArtifactDirectory = Environment.GetEnvironmentVariable("LEANCORPUS_ARTIFACT_DIR");
+        var runDir = !string.IsNullOrWhiteSpace(suppliedArtifactDirectory)
+            ? Path.GetFullPath(suppliedArtifactDirectory)
+            : Path.Combine(repoRoot, "artifacts", "benchmark", "runs",
+                now.ToString("yyyyMMdd-HHmmss", CultureInfo.InvariantCulture), "core");
+        var machineDir = Directory.GetParent(runDir)?.FullName ?? runDir;
         Directory.CreateDirectory(runDir);
 
         var gitCommitHash = GetGitShortHash(repoRoot);
@@ -58,7 +59,10 @@ internal static class Program
         var commitHash = !string.IsNullOrWhiteSpace(sourceCommit)
             ? sourceCommit
             : gitCommitHash;
-        var runId = string.IsNullOrEmpty(commitHash)
+        var orchestratedRunId = Environment.GetEnvironmentVariable("LEANCORPUS_RUN_ID");
+        var runId = !string.IsNullOrWhiteSpace(orchestratedRunId)
+            ? orchestratedRunId
+            : string.IsNullOrEmpty(commitHash)
             ? now.ToString("yyyy-MM-dd HH-mm", CultureInfo.InvariantCulture)
             : $"{now.ToString("yyyy-MM-dd HH-mm", CultureInfo.InvariantCulture)} ({commitHash})";
 
@@ -342,7 +346,7 @@ internal static class Program
         VectorQuantisationBenchmarks.CleanupLuceneResources();
         ParallelSearchBenchmarks.CleanupLuceneResources();
 
-        // Nuke the entire bench/tmp tree so subsequent runs start clean.
+        // Remove this run's benchmark temp tree so subsequent runs start clean.
         BenchmarkHelpers.CleanTempRoot();
 
         // Build and write consolidated report + index.json
@@ -705,7 +709,7 @@ internal static class Program
               ranking-pipeline    RankingPipelineBenchmarks -- profiles, rules and bounded reranking (explicit only)
 
             Output:
-              Results are written to bench/{machine-name}/{yyyy-MM-dd}/{HH-mm}/
+              Results are written under artifacts/benchmark/runs/.
               A consolidated JSON report and per-machine index.json are maintained.
 
             Examples:

--- a/src/devops/Rowles.LeanCorpus.Benchmarks/Program.cs
+++ b/src/devops/Rowles.LeanCorpus.Benchmarks/Program.cs
@@ -372,7 +372,9 @@ internal static class Program
         Console.WriteLine($"Commit: {(string.IsNullOrEmpty(commitHash) ? "(unknown)" : commitHash)}");
         Console.WriteLine($"Output: {runDir}");
         Console.WriteLine($"Suites: {string.Join(", ", suiteSummaries.Select(s => s.Suite))}");
-        return 0;
+        var hasInvalidResults = suiteSummaries.Any(item => item.Summary.HasCriticalValidationErrors) ||
+            report.Suites.Any(suite => suite.FailedBenchmarkCount > 0 || suite.MissingBenchmarkCount > 0);
+        return hasInvalidResults ? 1 : 0;
     }
 
     private static void RunSuite<T>(

--- a/src/devops/Rowles.LeanCorpus.Tests.AOTSmoke/Rowles.LeanCorpus.Tests.AOTSmoke.csproj
+++ b/src/devops/Rowles.LeanCorpus.Tests.AOTSmoke/Rowles.LeanCorpus.Tests.AOTSmoke.csproj
@@ -4,20 +4,17 @@
     <OutputType>Exe</OutputType>
     <PublishAot>true</PublishAot>
     <IsAotCompatible>true</IsAotCompatible>
-    <IsTestProject>false</IsTestProject>
-    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <IsTestProject>true</IsTestProject>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.v3.aot" Version="4.0.0-pre.128" />
-    <PackageReference Include="xunit.v3.assert.aot" Version="4.0.0-pre.128" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0-pre.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit.v3.aot" />
+    <PackageReference Include="xunit.v3.aot.mtp-v2" />
+    <PackageReference Include="xunit.v3.assert.aot" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/devops/Rowles.LeanCorpus.Tests.Architecture/Rowles.LeanCorpus.Tests.Architecture.csproj
+++ b/src/devops/Rowles.LeanCorpus.Tests.Architecture/Rowles.LeanCorpus.Tests.Architecture.csproj
@@ -10,7 +10,13 @@
   <ItemGroup>
     <PackageReference Include="TngTech.ArchUnitNET" />
     <PackageReference Include="TngTech.ArchUnitNET.xUnitV3" />
+    <PackageReference Include="Microsoft.Testing.Extensions.GitHubActionsReport" />
     <PackageReference Include="xunit.v3.mtp-v2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Rowles.LeanCorpus.Tests.Shared\Diagnostics\LeanCorpusTestDiagnostics.cs" Link="Diagnostics\LeanCorpusTestDiagnostics.cs" />
+    <Compile Include="..\Rowles.LeanCorpus.Tests.Shared\Diagnostics\LeanCorpusTestTelemetryFixture.cs" Link="Diagnostics\LeanCorpusTestTelemetryFixture.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/devops/Rowles.LeanCorpus.Tests.Core/Foundation/Unit/MetadataClassificationTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Core/Foundation/Unit/MetadataClassificationTests.cs
@@ -103,9 +103,11 @@ public sealed class MetadataClassificationTests
     private static string GetProjectDirectory()
     {
         var directory = new DirectoryInfo(AppContext.BaseDirectory);
-        while (directory is not null && directory.Name != "Rowles.LeanCorpus.Tests.Core")
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Rowles.LeanCorpus.slnx")))
             directory = directory.Parent;
 
-        return directory?.FullName ?? throw new InvalidOperationException("Could not find the Core test project directory.");
+        return directory is null
+            ? throw new InvalidOperationException("Could not find the LeanCorpus repository root.")
+            : Path.Combine(directory.FullName, "src", "devops", "Rowles.LeanCorpus.Tests.Core");
     }
 }

--- a/src/devops/Rowles.LeanCorpus.Tests.Core/Index/Integration/CommitSearcherRaceReproTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Core/Index/Integration/CommitSearcherRaceReproTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Rowles.LeanCorpus.Document;
 using Rowles.LeanCorpus.Document.Fields;
 using Rowles.LeanCorpus.Index.Indexer;
@@ -106,25 +107,27 @@ public sealed class CommitSearcherRaceReproTests : IClassFixture<TestDirectoryFi
     /// cleanup runs concurrently with later commits. This directly exercises the
     /// Windows-specific file-lifetime race without relying on a long iteration count.
     /// </summary>
-    [Fact(DisplayName = "Commit + SearcherManager stress: pinned generations survive merge churn", Timeout = 60_000)]
+    [Fact(DisplayName = "Commit + SearcherManager stress: pinned generations survive merge churn", Timeout = 120_000)]
     public void CommitWithSearcherManagerStressLoop_NoCrash()
     {
         var dirPath = SubDir("commit_searcher_stress");
-        using var dir = new MMapDirectory(dirPath);
-        using var writer = new IndexWriter(dir, new IndexWriterConfig
-        {
-            DurableCommits = false,
-            MaxBufferedDocs = 1,
-            MergePolicy = new TieredMergePolicy(2)
-        });
-        using var manager = new SearcherManager(dir, null);
-
+        var dir = new MMapDirectory(dirPath);
+        IndexWriter? writer = null;
+        SearcherManager? manager = null;
         const int iterations = 120;
         const int pinnedGenerations = 8;
         var heldSearchers = new Queue<IndexSearcher>();
 
         try
         {
+            writer = new IndexWriter(dir, new IndexWriterConfig
+            {
+                DurableCommits = false,
+                MaxBufferedDocs = 1,
+                MergePolicy = new TieredMergePolicy(2)
+            });
+            manager = new SearcherManager(dir, null);
+
             for (int i = 0; i < iterations; i++)
             {
                 var key = $"item_{i}";
@@ -155,16 +158,57 @@ public sealed class CommitSearcherRaceReproTests : IClassFixture<TestDirectoryFi
                     }
                 }
             }
+
+            manager.MaybeRefresh();
+            int finalCount = manager.UsingSearcher(s => s.Search(new TermQuery("body", "lorem"), 1000).ScoreDocs.Length);
+            Assert.True(finalCount > 0, "Expected to find documents after pinned-generation merge churn.");
+            _output.WriteLine($"Pinned-generation stress complete. Final searcher found {finalCount} matching documents.");
         }
         finally
         {
-            while (heldSearchers.TryDequeue(out var searcher))
-                manager.Release(searcher);
+            try
+            {
+                TimeCleanup("held searchers released", () =>
+                {
+                    while (heldSearchers.TryDequeue(out var searcher))
+                        manager?.Release(searcher);
+                });
+            }
+            finally
+            {
+                try
+                {
+                    if (manager is not null)
+                        TimeCleanup("SearcherManager.Dispose", manager.Dispose);
+                }
+                finally
+                {
+                    try
+                    {
+                        if (writer is not null)
+                            TimeCleanup("IndexWriter.Dispose", writer.Dispose);
+                    }
+                    finally
+                    {
+                        TimeCleanup("MMapDirectory.Dispose", dir.Dispose);
+                    }
+                }
+            }
         }
+    }
 
-        manager.MaybeRefresh();
-        int finalCount = manager.UsingSearcher(s => s.Search(new TermQuery("body", "lorem"), 1000).ScoreDocs.Length);
-        Assert.True(finalCount > 0, "Expected to find documents after pinned-generation merge churn.");
-        _output.WriteLine($"Pinned-generation stress complete. Final searcher found {finalCount} matching documents.");
+    private void TimeCleanup(string operation, Action action)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            action();
+            _output.WriteLine($"[cleanup] {operation} completed in {stopwatch.Elapsed.TotalMilliseconds:N1} ms");
+        }
+        catch
+        {
+            _output.WriteLine($"[cleanup] {operation} failed after {stopwatch.Elapsed.TotalMilliseconds:N1} ms");
+            throw;
+        }
     }
 }

--- a/src/devops/Rowles.LeanCorpus.Tests.Core/Rowles.LeanCorpus.Tests.Core.csproj
+++ b/src/devops/Rowles.LeanCorpus.Tests.Core/Rowles.LeanCorpus.Tests.Core.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="FsCheck.Xunit.v3" />
     <PackageReference Include="Microsoft.Testing.Extensions.CrashDump" />
     <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
+    <PackageReference Include="Microsoft.Testing.Extensions.GitHubActionsReport" />
     <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>
 
@@ -37,6 +38,10 @@
              Link="Foundation\Infrastructure\MaterialisingTokenSink.cs" />
     <Compile Include="..\Rowles.LeanCorpus.Tests.Shared\Metamorphic\MetamorphicRelations.cs"
              Link="Foundation\Metamorphic\MetamorphicRelations.cs" />
+    <Compile Include="..\Rowles.LeanCorpus.Tests.Shared\Diagnostics\LeanCorpusTestDiagnostics.cs"
+             Link="Foundation\Diagnostics\LeanCorpusTestDiagnostics.cs" />
+    <Compile Include="..\Rowles.LeanCorpus.Tests.Shared\Diagnostics\LeanCorpusTestTelemetryFixture.cs"
+             Link="Foundation\Diagnostics\LeanCorpusTestTelemetryFixture.cs" />
   </ItemGroup>
 
   <!-- Historical fixture bytes: keep the manifest names stable regardless of project. -->

--- a/src/devops/Rowles.LeanCorpus.Tests.Shared/Diagnostics/LeanCorpusTestDiagnostics.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Shared/Diagnostics/LeanCorpusTestDiagnostics.cs
@@ -1,0 +1,25 @@
+using System.Text.Json;
+using Xunit;
+
+namespace Rowles.LeanCorpus.Tests.Shared.Diagnostics;
+
+internal static class LeanCorpusTestDiagnostics
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    public static void AttachJson<T>(string name, T value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        TestContext.Current.AddAttachment(name, JsonSerializer.SerializeToUtf8Bytes(value, JsonOptions), "application/json");
+    }
+
+    public static void AttachIndexState<T>(T state) => AttachJson("index-state.json", state);
+
+    public static void Warning(string message)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+        TestContext.Current.AddWarning(message);
+    }
+
+    public static CancellationToken CancellationToken => TestContext.Current.CancellationToken;
+}

--- a/src/devops/Rowles.LeanCorpus.Tests.Shared/Diagnostics/LeanCorpusTestTelemetryFixture.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Shared/Diagnostics/LeanCorpusTestTelemetryFixture.cs
@@ -109,6 +109,10 @@ public sealed class LeanCorpusTestTelemetryFixture : INotifyTestLifecycle, IDisp
         root.SetTag("test.id", testId);
         root.SetTag("test.name", test.TestDisplayName);
         root.SetTag("test.label", test.TestLabel);
+        root.SetTag("test.class", test.TestCase.TestClassName);
+        root.SetTag("test.method", test.TestCase.TestMethodName);
+        root.SetTag("test.suite", Environment.GetEnvironmentVariable("LEANCORPUS_SUITE"));
+        root.SetTag("test.category", GetTraitValues(test.TestCase.Traits, "Category"));
         root.SetTag("test.run_id", Environment.GetEnvironmentVariable("LEANCORPUS_RUN_ID"));
         root.SetTag("test.target", Environment.GetEnvironmentVariable("LEANCORPUS_TARGET"));
         root.SetTag("test.iteration", Environment.GetEnvironmentVariable("LEANCORPUS_ITERATION"));
@@ -205,6 +209,9 @@ public sealed class LeanCorpusTestTelemetryFixture : INotifyTestLifecycle, IDisp
         }
         return new string(buffer[..length]);
     }
+
+    private static string GetTraitValues(IReadOnlyDictionary<string, IReadOnlyCollection<string>> traits, string name) =>
+        traits.TryGetValue(name, out IReadOnlyCollection<string>? values) ? string.Join(',', values) : string.Empty;
 
     private static StreamWriter CreateWriter(string path) =>
         new(path, append: false, new System.Text.UTF8Encoding(false)) { AutoFlush = true };
@@ -311,7 +318,12 @@ public sealed class LeanCorpusTestTelemetryFixture : INotifyTestLifecycle, IDisp
                         durationMs = activity.Duration.TotalMilliseconds,
                         status = activity.Status.ToString(),
                         tags = activity.TagObjects.ToDictionary(item => item.Key, item => item.Value),
-                        events = activity.Events.Select(item => new { item.Name, item.Timestamp }).ToArray(),
+                        events = activity.Events.Select(item => new
+                        {
+                            item.Name,
+                            item.Timestamp,
+                            tags = item.Tags.ToDictionary(tag => tag.Key, tag => tag.Value),
+                        }).ToArray(),
                     });
                 }
             }

--- a/src/devops/Rowles.LeanCorpus.Tests.Shared/Diagnostics/LeanCorpusTestTelemetryFixture.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Shared/Diagnostics/LeanCorpusTestTelemetryFixture.cs
@@ -88,41 +88,50 @@ public sealed class LeanCorpusTestTelemetryFixture : INotifyTestLifecycle, IDisp
             return;
 
         string testId = test.UniqueID;
-        string testDirectory = Path.Combine(executionDirectory, "telemetry", "tests", SanitisePath(testId));
-        var session = new TestTelemetrySession(testId, test.TestDisplayName, testDirectory, telemetryMode == "full");
-        if (!sessionsByTestId.TryAdd(testId, session))
+        TestTelemetrySession? session = null;
+        Activity? root = null;
+        try
         {
-            session.Dispose();
-            TestContext.Current.AddWarning($"Duplicate telemetry session for test '{testId}'.");
-            return;
-        }
+            string testDirectory = Path.Combine(executionDirectory, "telemetry", "tests", SanitisePath(testId));
+            session = new TestTelemetrySession(testId, test.TestDisplayName, testDirectory, telemetryMode == "full");
+            if (!sessionsByTestId.TryAdd(testId, session))
+            {
+                session.Dispose();
+                TryAddWarning($"Duplicate telemetry session for test '{testId}'.");
+                return;
+            }
 
-        Activity? root = testSource.StartActivity("leancorpus.test", ActivityKind.Internal);
-        if (root is null)
+            root = testSource.StartActivity("leancorpus.test", ActivityKind.Internal);
+            if (root is null)
+                throw new InvalidOperationException("The LeanCorpus test telemetry root activity could not be created.");
+
+            root.SetTag("test.id", testId);
+            root.SetTag("test.name", test.TestDisplayName);
+            root.SetTag("test.label", test.TestLabel);
+            root.SetTag("test.class", test.TestCase.TestClassName);
+            root.SetTag("test.method", test.TestCase.TestMethodName);
+            root.SetTag("test.suite", Environment.GetEnvironmentVariable("LEANCORPUS_SUITE"));
+            root.SetTag("test.category", GetTraitValues(test.TestCase.Traits, "Category"));
+            root.SetTag("test.run_id", Environment.GetEnvironmentVariable("LEANCORPUS_RUN_ID"));
+            root.SetTag("test.target", Environment.GetEnvironmentVariable("LEANCORPUS_TARGET"));
+            root.SetTag("test.iteration", Environment.GetEnvironmentVariable("LEANCORPUS_ITERATION"));
+            root.SetTag("dotnet.framework", AppContext.TargetFrameworkName);
+            root.SetTag("os.type", Environment.OSVersion.Platform.ToString());
+            root.SetTag("os.arch", System.Runtime.InteropServices.RuntimeInformation.OSArchitecture.ToString());
+            root.SetTag("process.id", Environment.ProcessId);
+            root.SetTag("ci", Environment.GetEnvironmentVariable("LEANCORPUS_CI"));
+            session.Root = root;
+            sessionsByTraceId[root.TraceId] = session;
+        }
+        catch (Exception exception)
         {
             sessionsByTestId.TryRemove(testId, out _);
-            session.Dispose();
-            TestContext.Current.AddWarning("The LeanCorpus test telemetry root activity could not be created.");
-            return;
+            if (root is not null)
+                sessionsByTraceId.TryRemove(root.TraceId, out _);
+            try { root?.Dispose(); } catch { }
+            try { session?.Dispose(); } catch { }
+            TryAddWarning($"LeanCorpus test telemetry setup failed: {exception.GetType().Name}: {exception.Message}");
         }
-
-        root.SetTag("test.id", testId);
-        root.SetTag("test.name", test.TestDisplayName);
-        root.SetTag("test.label", test.TestLabel);
-        root.SetTag("test.class", test.TestCase.TestClassName);
-        root.SetTag("test.method", test.TestCase.TestMethodName);
-        root.SetTag("test.suite", Environment.GetEnvironmentVariable("LEANCORPUS_SUITE"));
-        root.SetTag("test.category", GetTraitValues(test.TestCase.Traits, "Category"));
-        root.SetTag("test.run_id", Environment.GetEnvironmentVariable("LEANCORPUS_RUN_ID"));
-        root.SetTag("test.target", Environment.GetEnvironmentVariable("LEANCORPUS_TARGET"));
-        root.SetTag("test.iteration", Environment.GetEnvironmentVariable("LEANCORPUS_ITERATION"));
-        root.SetTag("dotnet.framework", AppContext.TargetFrameworkName);
-        root.SetTag("os.type", Environment.OSVersion.Platform.ToString());
-        root.SetTag("os.arch", System.Runtime.InteropServices.RuntimeInformation.OSArchitecture.ToString());
-        root.SetTag("process.id", Environment.ProcessId);
-        root.SetTag("ci", Environment.GetEnvironmentVariable("LEANCORPUS_CI"));
-        session.Root = root;
-        sessionsByTraceId[root.TraceId] = session;
     }
 
     public void OnTestFinished(IXunitTest test)
@@ -130,21 +139,47 @@ public sealed class LeanCorpusTestTelemetryFixture : INotifyTestLifecycle, IDisp
         if (!sessionsByTestId.TryRemove(test.UniqueID, out TestTelemetrySession? session))
             return;
 
-        session.Root?.Stop();
-        if (session.Root is not null)
-            sessionsByTraceId.TryRemove(session.Root.TraceId, out _);
-        session.Complete();
-
-        if (session.SwallowedExceptions > 0)
-            TestContext.Current.AddWarning($"LeanCorpus recorded {session.SwallowedExceptions} swallowed exception event(s).");
-
-        TestContext.Current.AddAttachment("leancorpus-telemetry-summary.json", File.ReadAllBytes(session.SummaryPath), "application/json");
-        if (session.FullTelemetry)
+        try
         {
-            TestContext.Current.AddAttachment("leancorpus-activities.ndjson", File.ReadAllBytes(session.ActivitiesPath), "application/x-ndjson");
-            TestContext.Current.AddAttachment("leancorpus-metrics.ndjson", File.ReadAllBytes(session.MetricsPath), "application/x-ndjson");
+            try
+            {
+                session.Root?.Stop();
+            }
+            catch (Exception exception)
+            {
+                session.RecordTelemetryError(exception);
+                TryAddWarning($"LeanCorpus test telemetry root shutdown failed: {exception.GetType().Name}: {exception.Message}");
+            }
+            finally
+            {
+                if (session.Root is not null)
+                    sessionsByTraceId.TryRemove(session.Root.TraceId, out _);
+            }
+
+            session.CloseWriters();
+            session.Complete();
+            if (session.SwallowedExceptions > 0)
+                TryAddWarning($"LeanCorpus recorded {session.SwallowedExceptions} swallowed exception event(s).");
+            TestContext.Current.AddAttachment(
+                "leancorpus-telemetry-summary.json",
+                File.ReadAllBytes(session.SummaryPath),
+                "application/json");
         }
-        session.Dispose();
+        catch (Exception exception)
+        {
+            session.RecordTelemetryError(exception);
+            try
+            {
+                session.CloseWriters();
+                session.Complete();
+            }
+            catch { }
+            TryAddWarning($"LeanCorpus test telemetry finalisation failed: {exception.GetType().Name}: {exception.Message}");
+        }
+        finally
+        {
+            session.Dispose();
+        }
     }
 
     public void Dispose()
@@ -169,32 +204,51 @@ public sealed class LeanCorpusTestTelemetryFixture : INotifyTestLifecycle, IDisp
     private void RecordActivity(Activity activity)
     {
         if (sessionsByTraceId.TryGetValue(activity.TraceId, out TestTelemetrySession? session))
-            session.RecordActivity(activity);
+        {
+            try { session.RecordActivity(activity); }
+            catch (Exception exception) { session.RecordTelemetryError(exception); }
+        }
     }
 
     private void RecordMeasurement<T>(Instrument instrument, T measurement,
         ReadOnlySpan<KeyValuePair<string, object?>> tags, object? state) where T : struct
     {
-        if (instrument.Meter.Name == RuntimeMeterName && runtimeWriter is not null)
+        TestTelemetrySession? session = null;
+        try
         {
-            lock (runtimeSync)
-            {
-                WriteLine(runtimeWriter, new
-                {
-                    instrument = instrument.Name,
-                    unit = instrument.Unit,
-                    timestampUtc = DateTimeOffset.UtcNow,
-                    value = Convert.ToString(measurement, CultureInfo.InvariantCulture),
-                    testTraceId = Activity.Current?.TraceId.ToHexString(),
-                    tags = tags.ToArray().ToDictionary(item => item.Key, item => item.Value),
-                });
-            }
-            return;
-        }
+            Activity? current = Activity.Current;
+            if (current is not null)
+                sessionsByTraceId.TryGetValue(current.TraceId, out session);
 
-        Activity? current = Activity.Current;
-        if (current is not null && sessionsByTraceId.TryGetValue(current.TraceId, out TestTelemetrySession? session))
-            session.RecordMeasurement(instrument, measurement, tags);
+            if (instrument.Meter.Name == RuntimeMeterName && runtimeWriter is not null)
+            {
+                lock (runtimeSync)
+                {
+                    WriteLine(runtimeWriter, new
+                    {
+                        instrument = instrument.Name,
+                        unit = instrument.Unit,
+                        timestampUtc = DateTimeOffset.UtcNow,
+                        value = Convert.ToString(measurement, CultureInfo.InvariantCulture),
+                        testTraceId = current?.TraceId.ToHexString(),
+                        tags = tags.ToArray().ToDictionary(item => item.Key, item => item.Value),
+                    });
+                }
+                return;
+            }
+
+            session?.RecordMeasurement(instrument, measurement, tags);
+        }
+        catch (Exception exception)
+        {
+            session?.RecordTelemetryError(exception);
+        }
+    }
+
+    private static void TryAddWarning(string message)
+    {
+        try { TestContext.Current.AddWarning(message); }
+        catch { }
     }
 
     private static string SanitisePath(string value)
@@ -259,7 +313,9 @@ public sealed class LeanCorpusTestTelemetryFixture : INotifyTestLifecycle, IDisp
         private readonly Dictionary<string, OperationSummary> operations = new(StringComparer.Ordinal);
         private readonly StreamWriter? activityWriter;
         private readonly StreamWriter? metricWriter;
+        private readonly List<string> telemetryErrors = [];
         private bool completed;
+        private bool writersClosed;
 
         public TestTelemetrySession(string testId, string testName, string directory, bool fullTelemetry)
         {
@@ -293,6 +349,22 @@ public sealed class LeanCorpusTestTelemetryFixture : INotifyTestLifecycle, IDisp
         public int MetricCount { get; private set; }
         public int SwallowedExceptions { get; private set; }
         public int OrphanedActivities { get; private set; }
+        public int TelemetryErrorCount { get; private set; }
+
+        public void RecordTelemetryError(Exception exception)
+        {
+            try
+            {
+                lock (sync)
+                {
+                    TelemetryErrorCount++;
+                    if (telemetryErrors.Count < 8)
+                        telemetryErrors.Add($"{exception.GetType().Name}: {exception.Message}");
+                    completed = false;
+                }
+            }
+            catch { }
+        }
 
         public void RecordActivity(Activity activity)
         {
@@ -362,9 +434,11 @@ public sealed class LeanCorpusTestTelemetryFixture : INotifyTestLifecycle, IDisp
             {
                 if (completed)
                     return;
-                completed = true;
-                activityWriter?.Flush();
-                metricWriter?.Flush();
+                if (!writersClosed)
+                {
+                    activityWriter?.Flush();
+                    metricWriter?.Flush();
+                }
                 var summary = new
                 {
                     testId = TestId,
@@ -377,16 +451,41 @@ public sealed class LeanCorpusTestTelemetryFixture : INotifyTestLifecycle, IDisp
                         item => new { item.Value.Count, durationMs = item.Value.DurationMs }),
                     swallowedExceptions = SwallowedExceptions,
                     orphanedActivities = OrphanedActivities,
+                    telemetryErrorCount = TelemetryErrorCount,
+                    telemetryErrors = telemetryErrors.ToArray(),
+                    activitiesFile = FullTelemetry ? Path.GetFileName(ActivitiesPath) : null,
+                    metricsFile = FullTelemetry ? Path.GetFileName(MetricsPath) : null,
                 };
                 File.WriteAllText(SummaryPath, JsonSerializer.Serialize(summary, new JsonSerializerOptions(JsonOptions) { WriteIndented = true }));
+                completed = true;
             }
+        }
+
+        public void CloseWriters()
+        {
+            Exception? activityError = null;
+            Exception? metricError = null;
+            lock (sync)
+            {
+                if (writersClosed)
+                    return;
+                writersClosed = true;
+                try { activityWriter?.Dispose(); }
+                catch (Exception exception) { activityError = exception; }
+                try { metricWriter?.Dispose(); }
+                catch (Exception exception) { metricError = exception; }
+            }
+            if (activityError is not null)
+                RecordTelemetryError(activityError);
+            if (metricError is not null)
+                RecordTelemetryError(metricError);
         }
 
         public void Dispose()
         {
-            Complete();
-            activityWriter?.Dispose();
-            metricWriter?.Dispose();
+            CloseWriters();
+            try { Complete(); }
+            catch { }
         }
 
         private sealed class OperationSummary

--- a/src/devops/Rowles.LeanCorpus.Tests.Shared/Diagnostics/LeanCorpusTestTelemetryFixture.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Shared/Diagnostics/LeanCorpusTestTelemetryFixture.cs
@@ -1,0 +1,386 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Globalization;
+using System.Text.Json;
+using Xunit;
+using Xunit.v3;
+
+[assembly: AssemblyFixture<Rowles.LeanCorpus.Tests.Shared.Diagnostics.LeanCorpusTestTelemetryFixture>]
+[assembly: CaptureConsole]
+[assembly: CaptureTrace]
+
+namespace Rowles.LeanCorpus.Tests.Shared.Diagnostics;
+
+public sealed class LeanCorpusTestTelemetryFixture : INotifyTestLifecycle, IDisposable
+{
+    private const string ApplicationSourceName = "Rowles.LeanCorpus";
+    private const string TestSourceName = "Rowles.LeanCorpus.Tests";
+    private const string RuntimeMeterName = "System.Runtime";
+    private readonly ActivitySource testSource = new(TestSourceName);
+    private readonly ConcurrentDictionary<string, TestTelemetrySession> sessionsByTestId = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<ActivityTraceId, TestTelemetrySession> sessionsByTraceId = new();
+    private readonly ActivityListener? activityListener;
+    private readonly MeterListener? meterListener;
+    private readonly Lock runtimeSync = new();
+    private readonly StreamWriter? runtimeWriter;
+    private readonly Timer? runtimeTimer;
+    private readonly string telemetryMode;
+    private bool disposed;
+
+    public LeanCorpusTestTelemetryFixture()
+    {
+        telemetryMode = Environment.GetEnvironmentVariable("LEANCORPUS_TELEMETRY")?.ToLowerInvariant() ?? "off";
+        if (telemetryMode == "off")
+            return;
+
+        if (telemetryMode == "full")
+        {
+            string? executionDirectory = Environment.GetEnvironmentVariable("LEANCORPUS_ARTIFACT_DIR");
+            if (!string.IsNullOrWhiteSpace(executionDirectory))
+            {
+                string runtimeDirectory = Path.Combine(executionDirectory, "runtime");
+                Directory.CreateDirectory(runtimeDirectory);
+                runtimeWriter = CreateWriter(Path.Combine(runtimeDirectory, "counters.ndjson"));
+            }
+        }
+
+        activityListener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name is ApplicationSourceName or TestSourceName,
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            SampleUsingParentId = static (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = RecordActivity,
+        };
+        ActivitySource.AddActivityListener(activityListener);
+
+        meterListener = new MeterListener
+        {
+            InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == ApplicationSourceName ||
+                    telemetryMode == "full" && instrument.Meter.Name == RuntimeMeterName)
+                    listener.EnableMeasurementEvents(instrument);
+            },
+        };
+        meterListener.SetMeasurementEventCallback<byte>(RecordMeasurement);
+        meterListener.SetMeasurementEventCallback<short>(RecordMeasurement);
+        meterListener.SetMeasurementEventCallback<int>(RecordMeasurement);
+        meterListener.SetMeasurementEventCallback<long>(RecordMeasurement);
+        meterListener.SetMeasurementEventCallback<float>(RecordMeasurement);
+        meterListener.SetMeasurementEventCallback<double>(RecordMeasurement);
+        meterListener.SetMeasurementEventCallback<decimal>(RecordMeasurement);
+        meterListener.Start();
+        if (runtimeWriter is not null)
+        {
+            WriteRuntimeSnapshot();
+            runtimeTimer = new Timer(_ => WriteRuntimeSnapshot(), null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+        }
+    }
+
+    public void OnTestStarting(IXunitTest test)
+    {
+        if (telemetryMode == "off")
+            return;
+
+        string? executionDirectory = Environment.GetEnvironmentVariable("LEANCORPUS_ARTIFACT_DIR");
+        if (string.IsNullOrWhiteSpace(executionDirectory))
+            return;
+
+        string testId = test.UniqueID;
+        string testDirectory = Path.Combine(executionDirectory, "telemetry", "tests", SanitisePath(testId));
+        var session = new TestTelemetrySession(testId, test.TestDisplayName, testDirectory, telemetryMode == "full");
+        if (!sessionsByTestId.TryAdd(testId, session))
+        {
+            session.Dispose();
+            TestContext.Current.AddWarning($"Duplicate telemetry session for test '{testId}'.");
+            return;
+        }
+
+        Activity? root = testSource.StartActivity("leancorpus.test", ActivityKind.Internal);
+        if (root is null)
+        {
+            sessionsByTestId.TryRemove(testId, out _);
+            session.Dispose();
+            TestContext.Current.AddWarning("The LeanCorpus test telemetry root activity could not be created.");
+            return;
+        }
+
+        root.SetTag("test.id", testId);
+        root.SetTag("test.name", test.TestDisplayName);
+        root.SetTag("test.label", test.TestLabel);
+        root.SetTag("test.run_id", Environment.GetEnvironmentVariable("LEANCORPUS_RUN_ID"));
+        root.SetTag("test.target", Environment.GetEnvironmentVariable("LEANCORPUS_TARGET"));
+        root.SetTag("test.iteration", Environment.GetEnvironmentVariable("LEANCORPUS_ITERATION"));
+        root.SetTag("dotnet.framework", AppContext.TargetFrameworkName);
+        root.SetTag("os.type", Environment.OSVersion.Platform.ToString());
+        root.SetTag("os.arch", System.Runtime.InteropServices.RuntimeInformation.OSArchitecture.ToString());
+        root.SetTag("process.id", Environment.ProcessId);
+        root.SetTag("ci", Environment.GetEnvironmentVariable("LEANCORPUS_CI"));
+        session.Root = root;
+        sessionsByTraceId[root.TraceId] = session;
+    }
+
+    public void OnTestFinished(IXunitTest test)
+    {
+        if (!sessionsByTestId.TryRemove(test.UniqueID, out TestTelemetrySession? session))
+            return;
+
+        session.Root?.Stop();
+        if (session.Root is not null)
+            sessionsByTraceId.TryRemove(session.Root.TraceId, out _);
+        session.Complete();
+
+        if (session.SwallowedExceptions > 0)
+            TestContext.Current.AddWarning($"LeanCorpus recorded {session.SwallowedExceptions} swallowed exception event(s).");
+
+        TestContext.Current.AddAttachment("leancorpus-telemetry-summary.json", File.ReadAllBytes(session.SummaryPath), "application/json");
+        if (session.FullTelemetry)
+        {
+            TestContext.Current.AddAttachment("leancorpus-activities.ndjson", File.ReadAllBytes(session.ActivitiesPath), "application/x-ndjson");
+            TestContext.Current.AddAttachment("leancorpus-metrics.ndjson", File.ReadAllBytes(session.MetricsPath), "application/x-ndjson");
+        }
+        session.Dispose();
+    }
+
+    public void Dispose()
+    {
+        if (disposed)
+            return;
+        disposed = true;
+        runtimeTimer?.Dispose();
+        meterListener?.Dispose();
+        activityListener?.Dispose();
+        testSource.Dispose();
+        runtimeWriter?.Dispose();
+        foreach (TestTelemetrySession session in sessionsByTestId.Values)
+        {
+            session.MarkOrphaned();
+            session.Dispose();
+        }
+        sessionsByTestId.Clear();
+        sessionsByTraceId.Clear();
+    }
+
+    private void RecordActivity(Activity activity)
+    {
+        if (sessionsByTraceId.TryGetValue(activity.TraceId, out TestTelemetrySession? session))
+            session.RecordActivity(activity);
+    }
+
+    private void RecordMeasurement<T>(Instrument instrument, T measurement,
+        ReadOnlySpan<KeyValuePair<string, object?>> tags, object? state) where T : struct
+    {
+        if (instrument.Meter.Name == RuntimeMeterName && runtimeWriter is not null)
+        {
+            lock (runtimeSync)
+            {
+                WriteLine(runtimeWriter, new
+                {
+                    instrument = instrument.Name,
+                    unit = instrument.Unit,
+                    timestampUtc = DateTimeOffset.UtcNow,
+                    value = Convert.ToString(measurement, CultureInfo.InvariantCulture),
+                    testTraceId = Activity.Current?.TraceId.ToHexString(),
+                    tags = tags.ToArray().ToDictionary(item => item.Key, item => item.Value),
+                });
+            }
+            return;
+        }
+
+        Activity? current = Activity.Current;
+        if (current is not null && sessionsByTraceId.TryGetValue(current.TraceId, out TestTelemetrySession? session))
+            session.RecordMeasurement(instrument, measurement, tags);
+    }
+
+    private static string SanitisePath(string value)
+    {
+        Span<char> buffer = value.Length <= 128 ? stackalloc char[value.Length] : new char[value.Length];
+        int length = 0;
+        foreach (char character in value)
+        {
+            if (length == 96)
+                break;
+            buffer[length++] = char.IsAsciiLetterOrDigit(character) || character is '-' or '_' ? character : '_';
+        }
+        return new string(buffer[..length]);
+    }
+
+    private static StreamWriter CreateWriter(string path) =>
+        new(path, append: false, new System.Text.UTF8Encoding(false)) { AutoFlush = true };
+
+    private static void WriteLine(StreamWriter writer, object value) =>
+        writer.WriteLine(JsonSerializer.Serialize(value, TestTelemetrySession.JsonOptions));
+
+    private void WriteRuntimeSnapshot()
+    {
+        if (runtimeWriter is null || disposed)
+            return;
+
+        try
+        {
+            meterListener?.RecordObservableInstruments();
+            using Process process = Process.GetCurrentProcess();
+            lock (runtimeSync)
+            {
+                WriteLine(runtimeWriter, new
+                {
+                    timestampUtc = DateTimeOffset.UtcNow,
+                    processId = Environment.ProcessId,
+                    workingSetBytes = process.WorkingSet64,
+                    cpuTimeMs = process.TotalProcessorTime.TotalMilliseconds,
+                    threadCount = process.Threads.Count,
+                    threadPoolThreadCount = ThreadPool.ThreadCount,
+                    threadPoolPendingWorkItems = ThreadPool.PendingWorkItemCount,
+                    gcTotalMemoryBytes = GC.GetTotalMemory(false),
+                    gen0Collections = GC.CollectionCount(0),
+                    gen1Collections = GC.CollectionCount(1),
+                    gen2Collections = GC.CollectionCount(2),
+                });
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            // Shutdown raced with the periodic sample.
+        }
+    }
+
+    private sealed class TestTelemetrySession : IDisposable
+    {
+        internal static readonly JsonSerializerOptions JsonOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+        private readonly Lock sync = new();
+        private readonly Dictionary<string, OperationSummary> operations = new(StringComparer.Ordinal);
+        private readonly StreamWriter? activityWriter;
+        private readonly StreamWriter? metricWriter;
+        private bool completed;
+
+        public TestTelemetrySession(string testId, string testName, string directory, bool fullTelemetry)
+        {
+            TestId = testId;
+            TestName = testName;
+            Directory.CreateDirectory(directory);
+            FullTelemetry = fullTelemetry;
+            ActivitiesPath = Path.Combine(directory, "activities.ndjson");
+            MetricsPath = Path.Combine(directory, "metrics.ndjson");
+            SummaryPath = Path.Combine(directory, "summary.json");
+            if (fullTelemetry)
+            {
+                activityWriter = CreateWriter(ActivitiesPath);
+                metricWriter = CreateWriter(MetricsPath);
+            }
+            else
+            {
+                File.WriteAllText(ActivitiesPath, string.Empty);
+                File.WriteAllText(MetricsPath, string.Empty);
+            }
+        }
+
+        public string TestId { get; }
+        public string TestName { get; }
+        public bool FullTelemetry { get; }
+        public string ActivitiesPath { get; }
+        public string MetricsPath { get; }
+        public string SummaryPath { get; }
+        public Activity? Root { get; set; }
+        public int ActivityCount { get; private set; }
+        public int MetricCount { get; private set; }
+        public int SwallowedExceptions { get; private set; }
+        public int OrphanedActivities { get; private set; }
+
+        public void RecordActivity(Activity activity)
+        {
+            lock (sync)
+            {
+                ActivityCount++;
+                if (!operations.TryGetValue(activity.OperationName, out OperationSummary? operation))
+                    operations[activity.OperationName] = operation = new OperationSummary();
+                operation.Count++;
+                operation.DurationMs += activity.Duration.TotalMilliseconds;
+                int swallowed = activity.Events.Count(item => item.Name == "exception.swallowed");
+                SwallowedExceptions += swallowed;
+                if (activityWriter is not null)
+                {
+                    WriteLine(activityWriter, new
+                    {
+                        testId = TestId,
+                        traceId = activity.TraceId.ToHexString(),
+                        spanId = activity.SpanId.ToHexString(),
+                        parentSpanId = activity.ParentSpanId.ToHexString(),
+                        operation = activity.OperationName,
+                        startedAtUtc = activity.StartTimeUtc,
+                        durationMs = activity.Duration.TotalMilliseconds,
+                        status = activity.Status.ToString(),
+                        tags = activity.TagObjects.ToDictionary(item => item.Key, item => item.Value),
+                        events = activity.Events.Select(item => new { item.Name, item.Timestamp }).ToArray(),
+                    });
+                }
+            }
+        }
+
+        public void RecordMeasurement<T>(Instrument instrument, T measurement,
+            ReadOnlySpan<KeyValuePair<string, object?>> tags) where T : struct
+        {
+            lock (sync)
+            {
+                MetricCount++;
+                if (metricWriter is not null)
+                {
+                    WriteLine(metricWriter, new
+                    {
+                        testId = TestId,
+                        instrument = instrument.Name,
+                        timestampUtc = DateTimeOffset.UtcNow,
+                        value = Convert.ToString(measurement, CultureInfo.InvariantCulture),
+                        traceId = Activity.Current?.TraceId.ToHexString(),
+                        tags = tags.ToArray().ToDictionary(item => item.Key, item => item.Value),
+                    });
+                }
+            }
+        }
+
+        public void MarkOrphaned()
+        {
+            lock (sync) { OrphanedActivities++; }
+            Complete();
+        }
+
+        public void Complete()
+        {
+            lock (sync)
+            {
+                if (completed)
+                    return;
+                completed = true;
+                activityWriter?.Flush();
+                metricWriter?.Flush();
+                var summary = new
+                {
+                    testId = TestId,
+                    testName = TestName,
+                    activityCount = ActivityCount,
+                    metricCount = MetricCount,
+                    durationMs = Root?.Duration.TotalMilliseconds ?? 0,
+                    operations = operations.ToDictionary(
+                        item => item.Key,
+                        item => new { item.Value.Count, durationMs = item.Value.DurationMs }),
+                    swallowedExceptions = SwallowedExceptions,
+                    orphanedActivities = OrphanedActivities,
+                };
+                File.WriteAllText(SummaryPath, JsonSerializer.Serialize(summary, new JsonSerializerOptions(JsonOptions) { WriteIndented = true }));
+            }
+        }
+
+        public void Dispose()
+        {
+            Complete();
+            activityWriter?.Dispose();
+            metricWriter?.Dispose();
+        }
+
+        private sealed class OperationSummary
+        {
+            public int Count { get; set; }
+            public double DurationMs { get; set; }
+        }
+    }
+}

--- a/src/devops/Rowles.LeanCorpus.Tests.Shared/Diagnostics/LeanCorpusTestTelemetryFixture.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Shared/Diagnostics/LeanCorpusTestTelemetryFixture.cs
@@ -23,8 +23,8 @@ public sealed class LeanCorpusTestTelemetryFixture : INotifyTestLifecycle, IDisp
     private readonly ActivityListener? activityListener;
     private readonly MeterListener? meterListener;
     private readonly Lock runtimeSync = new();
-    private readonly StreamWriter? runtimeWriter;
-    private readonly Timer? runtimeTimer;
+    private StreamWriter? runtimeWriter;
+    private Timer? runtimeTimer;
     private readonly string telemetryMode;
     private bool disposed;
 
@@ -39,9 +39,16 @@ public sealed class LeanCorpusTestTelemetryFixture : INotifyTestLifecycle, IDisp
             string? executionDirectory = Environment.GetEnvironmentVariable("LEANCORPUS_ARTIFACT_DIR");
             if (!string.IsNullOrWhiteSpace(executionDirectory))
             {
-                string runtimeDirectory = Path.Combine(executionDirectory, "runtime");
-                Directory.CreateDirectory(runtimeDirectory);
-                runtimeWriter = CreateWriter(Path.Combine(runtimeDirectory, "counters.ndjson"));
+                try
+                {
+                    string runtimeDirectory = Path.Combine(executionDirectory, "runtime");
+                    Directory.CreateDirectory(runtimeDirectory);
+                    runtimeWriter = CreateWriter(Path.Combine(runtimeDirectory, "counters.ndjson"));
+                }
+                catch (Exception exception)
+                {
+                    TryAddWarning($"LeanCorpus runtime telemetry startup failed: {exception.GetType().Name}: {exception.Message}");
+                }
             }
         }
 
@@ -74,7 +81,17 @@ public sealed class LeanCorpusTestTelemetryFixture : INotifyTestLifecycle, IDisp
         if (runtimeWriter is not null)
         {
             WriteRuntimeSnapshot();
-            runtimeTimer = new Timer(_ => WriteRuntimeSnapshot(), null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+            if (runtimeWriter is not null)
+            {
+                try
+                {
+                    runtimeTimer = new Timer(_ => WriteRuntimeSnapshot(), null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+                }
+                catch (Exception exception)
+                {
+                    DisableRuntimeTelemetry(exception);
+                }
+            }
         }
     }
 
@@ -187,11 +204,10 @@ public sealed class LeanCorpusTestTelemetryFixture : INotifyTestLifecycle, IDisp
         if (disposed)
             return;
         disposed = true;
-        runtimeTimer?.Dispose();
+        DisableRuntimeTelemetry(null);
         meterListener?.Dispose();
         activityListener?.Dispose();
         testSource.Dispose();
-        runtimeWriter?.Dispose();
         foreach (TestTelemetrySession session in sessionsByTestId.Values)
         {
             session.MarkOrphaned();
@@ -220,11 +236,14 @@ public sealed class LeanCorpusTestTelemetryFixture : INotifyTestLifecycle, IDisp
             if (current is not null)
                 sessionsByTraceId.TryGetValue(current.TraceId, out session);
 
-            if (instrument.Meter.Name == RuntimeMeterName && runtimeWriter is not null)
+            if (instrument.Meter.Name == RuntimeMeterName)
             {
                 lock (runtimeSync)
                 {
-                    WriteLine(runtimeWriter, new
+                    StreamWriter? writer = runtimeWriter;
+                    if (writer is null)
+                        return;
+                    WriteLine(writer, new
                     {
                         instrument = instrument.Name,
                         unit = instrument.Unit,
@@ -241,7 +260,10 @@ public sealed class LeanCorpusTestTelemetryFixture : INotifyTestLifecycle, IDisp
         }
         catch (Exception exception)
         {
-            session?.RecordTelemetryError(exception);
+            if (instrument.Meter.Name == RuntimeMeterName)
+                DisableRuntimeTelemetry(exception);
+            else
+                session?.RecordTelemetryError(exception);
         }
     }
 
@@ -300,10 +322,29 @@ public sealed class LeanCorpusTestTelemetryFixture : INotifyTestLifecycle, IDisp
                 });
             }
         }
-        catch (ObjectDisposedException)
+        catch (Exception exception)
         {
-            // Shutdown raced with the periodic sample.
+            if (!disposed)
+                DisableRuntimeTelemetry(exception);
         }
+    }
+
+    private void DisableRuntimeTelemetry(Exception? exception)
+    {
+        Timer? timer;
+        StreamWriter? writer;
+        lock (runtimeSync)
+        {
+            timer = runtimeTimer;
+            writer = runtimeWriter;
+            runtimeTimer = null;
+            runtimeWriter = null;
+        }
+
+        try { timer?.Dispose(); } catch { }
+        try { writer?.Dispose(); } catch { }
+        if (exception is not null && !disposed)
+            TryAddWarning($"LeanCorpus runtime telemetry was disabled: {exception.GetType().Name}: {exception.Message}");
     }
 
     private sealed class TestTelemetrySession : IDisposable

--- a/src/devops/Rowles.LeanCorpus.Tests.Shared/Rowles.LeanCorpus.Tests.Shared.csproj
+++ b/src/devops/Rowles.LeanCorpus.Tests.Shared/Rowles.LeanCorpus.Tests.Shared.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Fixtures/Indexes/*.fixture.b64" />
+    <Compile Remove="Diagnostics/*.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/devops/Rowles.LeanCorpus.Tests.SourceGen/Rowles.LeanCorpus.Tests.SourceGen.csproj
+++ b/src/devops/Rowles.LeanCorpus.Tests.SourceGen/Rowles.LeanCorpus.Tests.SourceGen.csproj
@@ -14,8 +14,14 @@
     <PackageReference Include="coverlet.MTP" />
     <PackageReference Include="Microsoft.Testing.Extensions.CrashDump" />
     <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
+    <PackageReference Include="Microsoft.Testing.Extensions.GitHubActionsReport" />
     <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Rowles.LeanCorpus.Tests.Shared\Diagnostics\LeanCorpusTestDiagnostics.cs" Link="Diagnostics\LeanCorpusTestDiagnostics.cs" />
+    <Compile Include="..\Rowles.LeanCorpus.Tests.Shared\Diagnostics\LeanCorpusTestTelemetryFixture.cs" Link="Diagnostics\LeanCorpusTestTelemetryFixture.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/devops/Rowles.Text.Benchmarks/Program.cs
+++ b/src/devops/Rowles.Text.Benchmarks/Program.cs
@@ -1,3 +1,4 @@
+using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 
 namespace Rowles.Text.Benchmarks;
@@ -6,7 +7,11 @@ internal static class Program
 {
     public static int Main(string[] args)
     {
-        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+        string artifactsPath = Environment.GetEnvironmentVariable("LEANCORPUS_ARTIFACT_DIR")
+            ?? Path.Combine(Directory.GetCurrentDirectory(), "artifacts", "benchmark", "runs", "direct", "text");
+        Directory.CreateDirectory(artifactsPath);
+        var config = DefaultConfig.Instance.WithArtifactsPath(Path.Combine(artifactsPath, "_runner"));
+        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
         return 0;
     }
 }

--- a/src/devops/Rowles.Text.Benchmarks/Program.cs
+++ b/src/devops/Rowles.Text.Benchmarks/Program.cs
@@ -1,4 +1,5 @@
 using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
 
 namespace Rowles.Text.Benchmarks;
@@ -11,7 +12,16 @@ internal static class Program
             ?? Path.Combine(Directory.GetCurrentDirectory(), "artifacts", "benchmark", "runs", "direct", "text");
         Directory.CreateDirectory(artifactsPath);
         var config = DefaultConfig.Instance.WithArtifactsPath(Path.Combine(artifactsPath, "_runner"));
-        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
-        return 0;
+        var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
+        return HasInvalidResults(summaries) ? 1 : 0;
+    }
+
+    private static bool HasInvalidResults(IEnumerable<Summary> summaries)
+    {
+        var summaryArray = summaries.ToArray();
+        return summaryArray.Length == 0 || summaryArray.Any(summary =>
+            summary.HasCriticalValidationErrors ||
+            !summary.Reports.Any() ||
+            summary.Reports.Any(report => report.ResultStatistics is null));
     }
 }

--- a/src/devops/Rowles.Text.Benchmarks/Program.cs
+++ b/src/devops/Rowles.Text.Benchmarks/Program.cs
@@ -9,11 +9,26 @@ internal static class Program
     public static int Main(string[] args)
     {
         string artifactsPath = Environment.GetEnvironmentVariable("LEANCORPUS_ARTIFACT_DIR")
-            ?? Path.Combine(Directory.GetCurrentDirectory(), "artifacts", "benchmark", "runs", "direct", "text");
+            ?? Path.Combine(FindRepositoryRoot(), "artifacts", "benchmark", "runs", "direct", "text");
         Directory.CreateDirectory(artifactsPath);
         var config = DefaultConfig.Instance.WithArtifactsPath(Path.Combine(artifactsPath, "_runner"));
         var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
         return HasInvalidResults(summaries) ? 1 : 0;
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        foreach (string startPath in new[] { Directory.GetCurrentDirectory(), AppContext.BaseDirectory })
+        {
+            for (DirectoryInfo? directory = new(startPath); directory is not null; directory = directory.Parent)
+            {
+                if (File.Exists(Path.Combine(directory.FullName, "Rowles.LeanCorpus.slnx")))
+                    return directory.FullName;
+            }
+        }
+
+        throw new InvalidOperationException(
+            "LeanCorpus repository root could not be found. Run this benchmark through ./devops benchmark or from inside the repository.");
     }
 
     private static bool HasInvalidResults(IEnumerable<Summary> summaries)

--- a/src/devops/Rowles.Text.Tests/MetadataClassificationTests.cs
+++ b/src/devops/Rowles.Text.Tests/MetadataClassificationTests.cs
@@ -88,9 +88,11 @@ public sealed class MetadataClassificationTests
     private static string GetProjectDirectory()
     {
         var directory = new DirectoryInfo(AppContext.BaseDirectory);
-        while (directory is not null && directory.Name != "Rowles.Text.Tests")
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Rowles.LeanCorpus.slnx")))
             directory = directory.Parent;
 
-        return directory?.FullName ?? throw new InvalidOperationException("Could not find the Text test project directory.");
+        return directory is null
+            ? throw new InvalidOperationException("Could not find the LeanCorpus repository root.")
+            : Path.Combine(directory.FullName, "src", "devops", "Rowles.Text.Tests");
     }
 }

--- a/src/devops/Rowles.Text.Tests/Rowles.Text.Tests.csproj
+++ b/src/devops/Rowles.Text.Tests/Rowles.Text.Tests.csproj
@@ -4,6 +4,7 @@
     <PackageReference Include="coverlet.MTP" />
     <PackageReference Include="Microsoft.Testing.Extensions.CrashDump" />
     <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
+    <PackageReference Include="Microsoft.Testing.Extensions.GitHubActionsReport" />
     <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>
 
@@ -17,6 +18,8 @@
   <ItemGroup>
     <Compile Include="..\Rowles.LeanCorpus.Tests.Core\Metadata\TestMetadata.cs" Link="Metadata\TestMetadata.cs" />
     <Compile Include="..\Rowles.LeanCorpus.Tests.Shared\Infrastructure\MaterialisingTokenSink.cs" Link="Infrastructure\MaterialisingTokenSink.cs" />
+    <Compile Include="..\Rowles.LeanCorpus.Tests.Shared\Diagnostics\LeanCorpusTestDiagnostics.cs" Link="Diagnostics\LeanCorpusTestDiagnostics.cs" />
+    <Compile Include="..\Rowles.LeanCorpus.Tests.Shared\Diagnostics\LeanCorpusTestTelemetryFixture.cs" Link="Diagnostics\LeanCorpusTestTelemetryFixture.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/server/devops/Rowles.LeanCorpus.Server.Abstractions.Tests/Rowles.LeanCorpus.Server.Abstractions.Tests.csproj
+++ b/src/server/devops/Rowles.LeanCorpus.Server.Abstractions.Tests/Rowles.LeanCorpus.Server.Abstractions.Tests.csproj
@@ -12,7 +12,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Testing.Extensions.CrashDump" />
     <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
+    <PackageReference Include="Microsoft.Testing.Extensions.GitHubActionsReport" />
     <PackageReference Include="xunit.v3.mtp-v2" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="../../../devops/Rowles.LeanCorpus.Tests.Shared/Diagnostics/LeanCorpusTestDiagnostics.cs" Link="Diagnostics/LeanCorpusTestDiagnostics.cs" />
+    <Compile Include="../../../devops/Rowles.LeanCorpus.Tests.Shared/Diagnostics/LeanCorpusTestTelemetryFixture.cs" Link="Diagnostics/LeanCorpusTestTelemetryFixture.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../Rowles.LeanCorpus.Server.Abstractions/Rowles.LeanCorpus.Server.Abstractions.csproj" />

--- a/src/server/devops/Rowles.LeanCorpus.Server.Core.Tests/Rowles.LeanCorpus.Server.Core.Tests.csproj
+++ b/src/server/devops/Rowles.LeanCorpus.Server.Core.Tests/Rowles.LeanCorpus.Server.Core.Tests.csproj
@@ -12,7 +12,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Testing.Extensions.CrashDump" />
     <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
+    <PackageReference Include="Microsoft.Testing.Extensions.GitHubActionsReport" />
     <PackageReference Include="xunit.v3.mtp-v2" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="../../../devops/Rowles.LeanCorpus.Tests.Shared/Diagnostics/LeanCorpusTestDiagnostics.cs" Link="Diagnostics/LeanCorpusTestDiagnostics.cs" />
+    <Compile Include="../../../devops/Rowles.LeanCorpus.Tests.Shared/Diagnostics/LeanCorpusTestTelemetryFixture.cs" Link="Diagnostics/LeanCorpusTestTelemetryFixture.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../Rowles.LeanCorpus.Server.Core/Rowles.LeanCorpus.Server.Core.csproj" />

--- a/src/server/devops/Rowles.LeanCorpus.Server.Integration.Tests/Rowles.LeanCorpus.Server.Integration.Tests.csproj
+++ b/src/server/devops/Rowles.LeanCorpus.Server.Integration.Tests/Rowles.LeanCorpus.Server.Integration.Tests.csproj
@@ -14,7 +14,12 @@
     <PackageReference Include="Grpc.Net.Client" />
     <PackageReference Include="Microsoft.Testing.Extensions.CrashDump" />
     <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
+    <PackageReference Include="Microsoft.Testing.Extensions.GitHubActionsReport" />
     <PackageReference Include="xunit.v3.mtp-v2" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="../../../devops/Rowles.LeanCorpus.Tests.Shared/Diagnostics/LeanCorpusTestDiagnostics.cs" Link="Diagnostics/LeanCorpusTestDiagnostics.cs" />
+    <Compile Include="../../../devops/Rowles.LeanCorpus.Tests.Shared/Diagnostics/LeanCorpusTestTelemetryFixture.cs" Link="Diagnostics/LeanCorpusTestTelemetryFixture.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../Rowles.LeanCorpus.Server.AspNetCore/Rowles.LeanCorpus.Server.AspNetCore.csproj" />


### PR DESCRIPTION
This implements the Issue #79 infrastructure proposal, consolidating all DevOps output under `artifacts/`. I've moved testing fully to the xUnit 4 Microsoft Testing Platform stack, which brings in TRX and CTRF results, LeanCorpus telemetry, streaming diagnostics, and Native AOT support

The branch also adds clean and pack workflows, cross-module benchmark aggregation, and updated docs. During CI integration, I fixed executable discovery, safely handled missing telemetry, and corrected test paths

We now have [fancy new test summaries for builds](https://github.com/jordansrowles/LeanCorpus/actions/runs/34206663076), these are generated/provided by `Microsoft.Testing.Extensions.GitHubActionsReport`