### PR TITLE
Working on issue #76 strengthening architecture tests and boundaries

### DIFF
--- a/changelog/unreleased.md
+++ b/changelog/unreleased.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+* Strengthened architecture tests for package isolation, Server layering, filesystem ownership and Native AOT runtime IL-generation boundaries.
 * Bumped the LeanCorpus package to 3.1.1 for the stored-field persistence fix.
 * Consolidated build, test, coverage, benchmark, diagnostic and documentation output under the SDK artefact root; normal benchmark runs now cover Core, Rowles.Text and compression in one provenance-scoped run, and Native AOT smoke tests use the stable xUnit 4 MTP v2 stack.
 

--- a/changelog/unreleased.md
+++ b/changelog/unreleased.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-* Strengthened architecture tests for package isolation, Server layering, filesystem ownership and Native AOT runtime IL-generation boundaries.
+* Strengthened architecture tests for exact package and plugin isolation, Server transport boundaries, filesystem ownership, and Native AOT runtime generation and assembly-loading boundaries.
 * Bumped the LeanCorpus package to 3.1.1 for the stored-field persistence fix.
 * Consolidated build, test, coverage, benchmark, diagnostic and documentation output under the SDK artefact root; normal benchmark runs now cover Core, Rowles.Text and compression in one provenance-scoped run, and Native AOT smoke tests use the stable xUnit 4 MTP v2 stack.
 

--- a/changelog/unreleased.md
+++ b/changelog/unreleased.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-* Strengthened architecture tests for exact package and plugin isolation, Server transport boundaries, filesystem ownership, and Native AOT runtime generation and assembly-loading boundaries.
+* Strengthened architecture tests for exact package and plugin isolation, Server transport boundaries, filesystem ownership, and Native AOT runtime IL-generation boundaries.
 * Bumped the LeanCorpus package to 3.1.1 for the stored-field persistence fix.
 * Consolidated build, test, coverage, benchmark, diagnostic and documentation output under the SDK artefact root; normal benchmark runs now cover Core, Rowles.Text and compression in one provenance-scoped run, and Native AOT smoke tests use the stable xUnit 4 MTP v2 stack.
 

--- a/docs/changelog/unreleased.md
+++ b/docs/changelog/unreleased.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+* Strengthened architecture tests for package isolation, Server layering, filesystem ownership and Native AOT runtime IL-generation boundaries.
 * Bumped the LeanCorpus package to 3.1.1 for the stored-field persistence fix.
 * Consolidated build, test, coverage, benchmark, diagnostic and documentation output under the SDK artefact root; normal benchmark runs now cover Core, Rowles.Text and compression in one provenance-scoped run, and Native AOT smoke tests use the stable xUnit 4 MTP v2 stack.
 

--- a/docs/changelog/unreleased.md
+++ b/docs/changelog/unreleased.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-* Strengthened architecture tests for package isolation, Server layering, filesystem ownership and Native AOT runtime IL-generation boundaries.
+* Strengthened architecture tests for exact package and plugin isolation, Server transport boundaries, filesystem ownership, and Native AOT runtime generation and assembly-loading boundaries.
 * Bumped the LeanCorpus package to 3.1.1 for the stored-field persistence fix.
 * Consolidated build, test, coverage, benchmark, diagnostic and documentation output under the SDK artefact root; normal benchmark runs now cover Core, Rowles.Text and compression in one provenance-scoped run, and Native AOT smoke tests use the stable xUnit 4 MTP v2 stack.
 

--- a/docs/changelog/unreleased.md
+++ b/docs/changelog/unreleased.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-* Strengthened architecture tests for exact package and plugin isolation, Server transport boundaries, filesystem ownership, and Native AOT runtime generation and assembly-loading boundaries.
+* Strengthened architecture tests for exact package and plugin isolation, Server transport boundaries, filesystem ownership, and Native AOT runtime IL-generation boundaries.
 * Bumped the LeanCorpus package to 3.1.1 for the stored-field persistence fix.
 * Consolidated build, test, coverage, benchmark, diagnostic and documentation output under the SDK artefact root; normal benchmark runs now cover Core, Rowles.Text and compression in one provenance-scoped run, and Native AOT smoke tests use the stable xUnit 4 MTP v2 stack.
 

--- a/src/devops/Rowles.LeanCorpus.Tests.Architecture/AotBoundaryTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Architecture/AotBoundaryTests.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using System.Reflection.Emit;
 using Rowles.LeanCorpus.Tests.Architecture.Infrastructure;
 
@@ -29,16 +28,5 @@ public sealed class AotBoundaryTests
             dependency => ForbiddenTypes.Any(forbidden => DependencyInspector.IsExactType(dependency, forbidden)));
 
         RuleAssert.Empty("Production types must not depend on runtime IL-generation types:", failures);
-    }
-
-    [Fact]
-    public void Production_code_must_not_load_assemblies_at_runtime()
-    {
-        var failures = DependencyInspector.FindMethodCallViolations(
-            ArchitectureContext.CoreAssembly,
-            static _ => true,
-            static method => method.DeclaringType == typeof(Assembly) && method.Name.StartsWith("Load", StringComparison.Ordinal));
-
-        RuleAssert.Empty("Production types must not load assemblies at runtime:", failures);
     }
 }

--- a/src/devops/Rowles.LeanCorpus.Tests.Architecture/AotBoundaryTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Architecture/AotBoundaryTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Reflection.Emit;
 using Rowles.LeanCorpus.Tests.Architecture.Infrastructure;
 
@@ -28,5 +29,16 @@ public sealed class AotBoundaryTests
             dependency => ForbiddenTypes.Any(forbidden => DependencyInspector.IsExactType(dependency, forbidden)));
 
         RuleAssert.Empty("Production types must not depend on runtime IL-generation types:", failures);
+    }
+
+    [Fact]
+    public void Production_code_must_not_load_assemblies_at_runtime()
+    {
+        var failures = DependencyInspector.FindMethodCallViolations(
+            ArchitectureContext.CoreAssembly,
+            static _ => true,
+            static method => method.DeclaringType == typeof(Assembly) && method.Name.StartsWith("Load", StringComparison.Ordinal));
+
+        RuleAssert.Empty("Production types must not load assemblies at runtime:", failures);
     }
 }

--- a/src/devops/Rowles.LeanCorpus.Tests.Architecture/AotBoundaryTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Architecture/AotBoundaryTests.cs
@@ -1,0 +1,32 @@
+using System.Reflection.Emit;
+using Rowles.LeanCorpus.Tests.Architecture.Infrastructure;
+
+namespace Rowles.LeanCorpus.Tests.Architecture;
+
+public sealed class AotBoundaryTests
+{
+    private static readonly Type[] ForbiddenTypes =
+    [
+        typeof(DynamicMethod),
+        typeof(ILGenerator),
+        typeof(AssemblyBuilder),
+        typeof(ModuleBuilder),
+        typeof(TypeBuilder),
+        typeof(MethodBuilder),
+        typeof(ConstructorBuilder),
+        typeof(FieldBuilder),
+        typeof(PropertyBuilder),
+        typeof(EventBuilder),
+    ];
+
+    [Fact]
+    public void Production_code_must_not_depend_on_runtime_IL_generation()
+    {
+        var failures = DependencyInspector.FindViolations(
+            ArchitectureContext.CoreAssembly,
+            static _ => true,
+            dependency => ForbiddenTypes.Any(forbidden => DependencyInspector.IsExactType(dependency, forbidden)));
+
+        RuleAssert.Empty("Production types must not depend on runtime IL-generation types:", failures);
+    }
+}

--- a/src/devops/Rowles.LeanCorpus.Tests.Architecture/Infrastructure/DependencyInspector.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Architecture/Infrastructure/DependencyInspector.cs
@@ -69,13 +69,6 @@ internal static class DependencyInspector
 
     private static IEnumerable<Type> ReadMethodBodyDependencies(MethodBase method)
     {
-        foreach (MemberInfo member in ReadMethodBodyMembers(method))
-        foreach (var dependency in ExpandMember(member))
-            yield return dependency;
-    }
-
-    private static IEnumerable<MemberInfo> ReadMethodBodyMembers(MethodBase method)
-    {
         MethodBody? body;
         try
         {
@@ -106,7 +99,10 @@ internal static class DependencyInspector
                 int token = BitConverter.ToInt32(il, position);
                 MemberInfo? member = ResolveMember(method, token);
                 if (member is not null)
-                    yield return member;
+                {
+                    foreach (var dependency in ExpandMember(member))
+                        yield return dependency;
+                }
             }
 
             position += GetOperandSize(opCode.OperandType, il, position);

--- a/src/devops/Rowles.LeanCorpus.Tests.Architecture/Infrastructure/DependencyInspector.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Architecture/Infrastructure/DependencyInspector.cs
@@ -27,6 +27,22 @@ internal static class DependencyInspector
     internal static bool IsExactType(Type candidate, Type expected) =>
         Normalise(candidate) == Normalise(expected);
 
+    internal static IReadOnlyList<string> FindMethodCallViolations(
+        Assembly assembly,
+        Func<Type, bool> sourcePredicate,
+        Func<MethodBase, bool> methodPredicate)
+    {
+        var failures = new SortedSet<string>(StringComparer.Ordinal);
+
+        foreach (var type in assembly.GetTypes().Where(sourcePredicate))
+        {
+            if (GetMethodsCalledBy(type).Any(methodPredicate))
+                failures.Add(GetOwningType(type).FullName ?? GetOwningType(type).Name);
+        }
+
+        return failures.ToArray();
+    }
+
     private static IEnumerable<Type> GetDependencies(Type type)
     {
         foreach (var dependency in Expand(type.BaseType))
@@ -69,6 +85,25 @@ internal static class DependencyInspector
 
     private static IEnumerable<Type> ReadMethodBodyDependencies(MethodBase method)
     {
+        foreach (MemberInfo member in ReadMethodBodyMembers(method))
+        foreach (var dependency in ExpandMember(member))
+            yield return dependency;
+    }
+
+    private static IEnumerable<MethodBase> GetMethodsCalledBy(Type type)
+    {
+        const BindingFlags flags = BindingFlags.Instance | BindingFlags.Static |
+                                   BindingFlags.Public | BindingFlags.NonPublic |
+                                   BindingFlags.DeclaredOnly;
+
+        foreach (var method in type.GetMethods(flags).Cast<MethodBase>().Concat(type.GetConstructors(flags)))
+        foreach (MemberInfo member in ReadMethodBodyMembers(method))
+        if (member is MethodBase calledMethod)
+            yield return calledMethod;
+    }
+
+    private static IEnumerable<MemberInfo> ReadMethodBodyMembers(MethodBase method)
+    {
         MethodBody? body;
         try
         {
@@ -98,8 +133,8 @@ internal static class DependencyInspector
             {
                 int token = BitConverter.ToInt32(il, position);
                 MemberInfo? member = ResolveMember(method, token);
-                foreach (var dependency in ExpandMember(member))
-                    yield return dependency;
+                if (member is not null)
+                    yield return member;
             }
 
             position += GetOperandSize(opCode.OperandType, il, position);

--- a/src/devops/Rowles.LeanCorpus.Tests.Architecture/Infrastructure/DependencyInspector.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Architecture/Infrastructure/DependencyInspector.cs
@@ -27,22 +27,6 @@ internal static class DependencyInspector
     internal static bool IsExactType(Type candidate, Type expected) =>
         Normalise(candidate) == Normalise(expected);
 
-    internal static IReadOnlyList<string> FindMethodCallViolations(
-        Assembly assembly,
-        Func<Type, bool> sourcePredicate,
-        Func<MethodBase, bool> methodPredicate)
-    {
-        var failures = new SortedSet<string>(StringComparer.Ordinal);
-
-        foreach (var type in assembly.GetTypes().Where(sourcePredicate))
-        {
-            if (GetMethodsCalledBy(type).Any(methodPredicate))
-                failures.Add(GetOwningType(type).FullName ?? GetOwningType(type).Name);
-        }
-
-        return failures.ToArray();
-    }
-
     private static IEnumerable<Type> GetDependencies(Type type)
     {
         foreach (var dependency in Expand(type.BaseType))
@@ -88,18 +72,6 @@ internal static class DependencyInspector
         foreach (MemberInfo member in ReadMethodBodyMembers(method))
         foreach (var dependency in ExpandMember(member))
             yield return dependency;
-    }
-
-    private static IEnumerable<MethodBase> GetMethodsCalledBy(Type type)
-    {
-        const BindingFlags flags = BindingFlags.Instance | BindingFlags.Static |
-                                   BindingFlags.Public | BindingFlags.NonPublic |
-                                   BindingFlags.DeclaredOnly;
-
-        foreach (var method in type.GetMethods(flags).Cast<MethodBase>().Concat(type.GetConstructors(flags)))
-        foreach (MemberInfo member in ReadMethodBodyMembers(method))
-        if (member is MethodBase calledMethod)
-            yield return calledMethod;
     }
 
     private static IEnumerable<MemberInfo> ReadMethodBodyMembers(MethodBase method)

--- a/src/devops/Rowles.LeanCorpus.Tests.Architecture/Infrastructure/RepositoryPaths.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Architecture/Infrastructure/RepositoryPaths.cs
@@ -1,0 +1,29 @@
+namespace Rowles.LeanCorpus.Tests.Architecture.Infrastructure;
+
+internal static class RepositoryPaths
+{
+    internal static readonly string Root = FindRoot();
+
+    internal static string FromRoot(params string[] segments)
+    {
+        string path = Root;
+        foreach (string segment in segments)
+            path = Path.Combine(path, segment);
+
+        return path;
+    }
+
+    private static string FindRoot()
+    {
+        DirectoryInfo? current = new(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "Rowles.LeanCorpus.slnx")))
+                return current.FullName;
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the LeanCorpus repository root.");
+    }
+}

--- a/src/devops/Rowles.LeanCorpus.Tests.Architecture/Infrastructure/RuleInfrastructureTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Architecture/Infrastructure/RuleInfrastructureTests.cs
@@ -58,6 +58,17 @@ public sealed class RuleInfrastructureTests
     }
 
     [Fact]
+    public void Method_calls_are_detected()
+    {
+        var failures = DependencyInspector.FindMethodCallViolations(
+            typeof(AssemblyLoadingFixture).Assembly,
+            static type => type == typeof(AssemblyLoadingFixture),
+            static method => method.DeclaringType == typeof(System.Reflection.Assembly) && method.Name.StartsWith("Load", StringComparison.Ordinal));
+
+        Assert.Equal([typeof(AssemblyLoadingFixture).FullName!], failures);
+    }
+
+    [Fact]
     public void Failure_messages_are_sorted_and_readable()
     {
         string message = RuleAssert.FormatFailures("Broken rule:", ["Z.Type", "A.Type", "Z.Type"]);
@@ -86,5 +97,10 @@ public sealed class RuleInfrastructureTests
             var method = new System.Reflection.Emit.DynamicMethod("Fixture", null, Type.EmptyTypes);
             return method.GetILGenerator();
         }
+    }
+
+    private sealed class AssemblyLoadingFixture
+    {
+        internal System.Reflection.Assembly Load(string assemblyName) => System.Reflection.Assembly.Load(assemblyName);
     }
 }

--- a/src/devops/Rowles.LeanCorpus.Tests.Architecture/Infrastructure/RuleInfrastructureTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Architecture/Infrastructure/RuleInfrastructureTests.cs
@@ -58,17 +58,6 @@ public sealed class RuleInfrastructureTests
     }
 
     [Fact]
-    public void Method_calls_are_detected()
-    {
-        var failures = DependencyInspector.FindMethodCallViolations(
-            typeof(AssemblyLoadingFixture).Assembly,
-            static type => type == typeof(AssemblyLoadingFixture),
-            static method => method.DeclaringType == typeof(System.Reflection.Assembly) && method.Name.StartsWith("Load", StringComparison.Ordinal));
-
-        Assert.Equal([typeof(AssemblyLoadingFixture).FullName!], failures);
-    }
-
-    [Fact]
     public void Failure_messages_are_sorted_and_readable()
     {
         string message = RuleAssert.FormatFailures("Broken rule:", ["Z.Type", "A.Type", "Z.Type"]);
@@ -99,8 +88,4 @@ public sealed class RuleInfrastructureTests
         }
     }
 
-    private sealed class AssemblyLoadingFixture
-    {
-        internal System.Reflection.Assembly Load(string assemblyName) => System.Reflection.Assembly.Load(assemblyName);
-    }
 }

--- a/src/devops/Rowles.LeanCorpus.Tests.Architecture/Infrastructure/RuleInfrastructureTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Architecture/Infrastructure/RuleInfrastructureTests.cs
@@ -40,6 +40,24 @@ public sealed class RuleInfrastructureTests
     }
 
     [Fact]
+    public void Dynamic_code_generation_dependencies_are_detected()
+    {
+        var dynamicMethodFailures = DependencyInspector.FindViolations(
+            typeof(DynamicCodeGenerationFixture).Assembly,
+            static type => type == typeof(DynamicCodeGenerationFixture),
+            static dependency => DependencyInspector.IsExactType(dependency, typeof(System.Reflection.Emit.DynamicMethod)));
+
+        var ilGeneratorFailures = DependencyInspector.FindViolations(
+            typeof(DynamicCodeGenerationFixture).Assembly,
+            static type => type == typeof(DynamicCodeGenerationFixture),
+            static dependency => DependencyInspector.IsExactType(dependency, typeof(System.Reflection.Emit.ILGenerator)));
+
+        string fixtureName = typeof(DynamicCodeGenerationFixture).FullName!;
+        Assert.Equal([fixtureName], dynamicMethodFailures);
+        Assert.Equal([fixtureName], ilGeneratorFailures);
+    }
+
+    [Fact]
     public void Failure_messages_are_sorted_and_readable()
     {
         string message = RuleAssert.FormatFailures("Broken rule:", ["Z.Type", "A.Type", "Z.Type"]);
@@ -58,6 +76,15 @@ public sealed class RuleInfrastructureTests
         {
             await Task.Yield();
             return File.Exists(path);
+        }
+    }
+
+    private sealed class DynamicCodeGenerationFixture
+    {
+        internal System.Reflection.Emit.ILGenerator CreateGenerator()
+        {
+            var method = new System.Reflection.Emit.DynamicMethod("Fixture", null, Type.EmptyTypes);
+            return method.GetILGenerator();
         }
     }
 }

--- a/src/devops/Rowles.LeanCorpus.Tests.Architecture/IoBoundaryTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Architecture/IoBoundaryTests.cs
@@ -14,8 +14,6 @@ public sealed class IoBoundaryTests
         typeof(Directory),
         typeof(FileInfo),
         typeof(DirectoryInfo),
-        typeof(StreamReader),
-        typeof(StreamWriter),
         typeof(RandomAccess),
         typeof(SafeFileHandle),
         typeof(FileSystemWatcher),
@@ -26,7 +24,7 @@ public sealed class IoBoundaryTests
     {
         var failures = DependencyInspector.FindViolations(
             ArchitectureContext.CoreAssembly,
-            static type => !NamespaceSegments.Contains(type.Namespace, "Store"),
+            static type => type.Namespace is null || !type.Namespace.StartsWith("Rowles.LeanCorpus.Store", StringComparison.Ordinal),
             dependency => ForbiddenTypes.Any(forbidden => DependencyInspector.IsExactType(dependency, forbidden)));
 
         RuleAssert.Empty("Types outside Store must not depend on direct file-system IO types:", failures);

--- a/src/devops/Rowles.LeanCorpus.Tests.Architecture/IoBoundaryTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Architecture/IoBoundaryTests.cs
@@ -1,4 +1,5 @@
 using System.IO.MemoryMappedFiles;
+using Microsoft.Win32.SafeHandles;
 using Rowles.LeanCorpus.Tests.Architecture.Infrastructure;
 
 namespace Rowles.LeanCorpus.Tests.Architecture;
@@ -15,6 +16,9 @@ public sealed class IoBoundaryTests
         typeof(DirectoryInfo),
         typeof(StreamReader),
         typeof(StreamWriter),
+        typeof(RandomAccess),
+        typeof(SafeFileHandle),
+        typeof(FileSystemWatcher),
     ];
 
     [Fact]

--- a/src/devops/Rowles.LeanCorpus.Tests.Architecture/IoBoundaryTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Architecture/IoBoundaryTests.cs
@@ -17,6 +17,8 @@ public sealed class IoBoundaryTests
         typeof(RandomAccess),
         typeof(SafeFileHandle),
         typeof(FileSystemWatcher),
+        typeof(StreamReader),
+        typeof(StreamWriter),
     ];
 
     [Fact]
@@ -24,9 +26,13 @@ public sealed class IoBoundaryTests
     {
         var failures = DependencyInspector.FindViolations(
             ArchitectureContext.CoreAssembly,
-            static type => type.Namespace is null || !type.Namespace.StartsWith("Rowles.LeanCorpus.Store", StringComparison.Ordinal),
+            static type => IsOutsideStore(type.Namespace),
             dependency => ForbiddenTypes.Any(forbidden => DependencyInspector.IsExactType(dependency, forbidden)));
 
         RuleAssert.Empty("Types outside Store must not depend on direct file-system IO types:", failures);
     }
+
+    private static bool IsOutsideStore(string? @namespace) => @namespace is null ||
+        (@namespace != "Rowles.LeanCorpus.Store" &&
+         !@namespace.StartsWith("Rowles.LeanCorpus.Store.", StringComparison.Ordinal));
 }

--- a/src/devops/Rowles.LeanCorpus.Tests.Architecture/PackageBoundaryTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Architecture/PackageBoundaryTests.cs
@@ -36,11 +36,11 @@ public sealed class PackageBoundaryTests
         ];
 
         var failures = shippingProjects
-            .SelectMany(project => GetProjectReferences(project).Select(reference => (project, reference)))
-            .Where(static pair => IsTestOrDevelopmentProject(pair.reference))
+            .SelectMany(project => GetProjectReferenceIncludes(project).Select(reference => (project, reference)))
+            .Where(static pair => IsTestOrDevelopmentProject(pair.project, pair.reference))
             .Select(static pair => $"{pair.project} -> {pair.reference}");
 
-        RuleAssert.Empty("Shipping projects must not reference test, benchmark, profiling or example projects:", failures);
+        RuleAssert.Empty("Shipping projects must not reference devops, test, benchmark, profiling or example projects:", failures);
     }
 
     [Fact]
@@ -59,10 +59,9 @@ public sealed class PackageBoundaryTests
     {
         XDocument project = LoadProject("src/core/Rowles.LeanCorpus/Rowles.LeanCorpus.csproj");
         var runtimePackages = project.Descendants("PackageReference")
-            .Where(static reference => !string.Equals((string?)reference.Attribute("PrivateAssets"), "all", StringComparison.OrdinalIgnoreCase))
             .Select(static reference => (string?)reference.Attribute("Include") ?? "unnamed package");
 
-        RuleAssert.Empty("LeanCorpus package references must be build or analyser-only with PrivateAssets=all:", runtimePackages);
+        RuleAssert.Empty("LeanCorpus must not gain direct package references:", runtimePackages);
     }
 
     [Fact]
@@ -70,10 +69,9 @@ public sealed class PackageBoundaryTests
     {
         XDocument project = LoadProject("src/core/Rowles.Text/Rowles.Text.csproj");
         var runtimePackages = project.Descendants("PackageReference")
-            .Where(static reference => !string.Equals((string?)reference.Attribute("PrivateAssets"), "all", StringComparison.OrdinalIgnoreCase))
             .Select(static reference => (string?)reference.Attribute("Include") ?? "unnamed package");
 
-        RuleAssert.Empty("Rowles.Text package references must be build or analyser-only with PrivateAssets=all:", runtimePackages);
+        RuleAssert.Empty("Rowles.Text must not gain direct package references:", runtimePackages);
     }
 
     [Fact]
@@ -89,9 +87,14 @@ public sealed class PackageBoundaryTests
         foreach ((string projectPath, string implementation) in plugins)
         {
             XDocument project = LoadProject(projectPath);
-            Assert.Contains(GetProjectReferences(project), static reference => reference.Contains("Rowles.LeanCorpus", StringComparison.OrdinalIgnoreCase));
-            Assert.Contains(project.Descendants("PackageReference"), reference =>
-                string.Equals((string?)reference.Attribute("Include"), implementation, StringComparison.Ordinal));
+            string[] projectReferences = GetProjectReferences(projectPath);
+            Assert.Equal(["src/core/Rowles.LeanCorpus/Rowles.LeanCorpus.csproj"], projectReferences);
+
+            string[] packageReferences = project.Descendants("PackageReference")
+                .Select(static reference => (string?)reference.Attribute("Include"))
+                .OfType<string>()
+                .ToArray();
+            Assert.Equal([implementation], packageReferences);
         }
     }
 
@@ -162,9 +165,11 @@ public sealed class PackageBoundaryTests
         .Descendants("ProjectReference")
         .Select(static element => (string?)element.Attribute("Include"))
         .OfType<string>()
+        .Select(reference => ToRepositoryRelativePath(relativePath, reference))
         .ToArray();
 
-    private static string[] GetProjectReferences(XDocument project) => project.Descendants("ProjectReference")
+    private static string[] GetProjectReferenceIncludes(string relativePath) => LoadProject(relativePath)
+        .Descendants("ProjectReference")
         .Select(static element => (string?)element.Attribute("Include"))
         .OfType<string>()
         .ToArray();
@@ -173,9 +178,19 @@ public sealed class PackageBoundaryTests
         .Select(static element => element.Value.Trim())
         .SingleOrDefault();
 
-    private static bool IsTestOrDevelopmentProject(string reference) =>
-        reference.Contains(".Tests", StringComparison.OrdinalIgnoreCase) ||
-        reference.Contains(".Benchmarks", StringComparison.OrdinalIgnoreCase) ||
-        reference.Contains(".Profiling", StringComparison.OrdinalIgnoreCase) ||
-        reference.Contains("examples", StringComparison.OrdinalIgnoreCase);
+    private static bool IsTestOrDevelopmentProject(string projectPath, string reference)
+    {
+        string target = ToRepositoryRelativePath(projectPath, reference);
+        return target.StartsWith("src/devops/", StringComparison.OrdinalIgnoreCase) &&
+               !string.Equals(target, "src/devops/Rowles.LeanCorpus.Cli/Rowles.LeanCorpus.Cli.csproj", StringComparison.OrdinalIgnoreCase) ||
+               target.StartsWith("src/examples/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string ToRepositoryRelativePath(string projectPath, string reference)
+    {
+        string projectDirectory = Path.GetDirectoryName(Path.Combine(RepositoryPaths.Root, projectPath))!;
+        string normalisedReference = reference.Replace('\\', Path.DirectorySeparatorChar);
+        string target = Path.GetFullPath(Path.Combine(projectDirectory, normalisedReference));
+        return Path.GetRelativePath(RepositoryPaths.Root, target).Replace(Path.DirectorySeparatorChar, '/');
+    }
 }

--- a/src/devops/Rowles.LeanCorpus.Tests.Architecture/PackageBoundaryTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Architecture/PackageBoundaryTests.cs
@@ -1,5 +1,5 @@
-using System.Reflection;
 using System.Xml.Linq;
+using Rowles.LeanCorpus.Tests.Architecture.Infrastructure;
 
 namespace Rowles.LeanCorpus.Tests.Architecture;
 
@@ -16,13 +16,111 @@ public sealed class PackageBoundaryTests
     }
 
     [Fact]
+    public void Shipping_projects_must_not_reference_test_or_development_projects()
+    {
+        string[] shippingProjects =
+        [
+            "src/core/Rowles.LeanCorpus/Rowles.LeanCorpus.csproj",
+            "src/core/Rowles.Text/Rowles.Text.csproj",
+            "src/core/Rowles.LeanCorpus.SourceGen/Rowles.LeanCorpus.SourceGen.csproj",
+            "src/core/Rowles.LeanCorpus.Compression.LZ4/Rowles.LeanCorpus.Compression.LZ4.csproj",
+            "src/core/Rowles.LeanCorpus.Compression.Snappy/Rowles.LeanCorpus.Compression.Snappy.csproj",
+            "src/core/Rowles.LeanCorpus.Compression.Zstandard/Rowles.LeanCorpus.Compression.Zstandard.csproj",
+            "src/devops/Rowles.LeanCorpus.Cli/Rowles.LeanCorpus.Cli.csproj",
+            "src/server/Rowles.LeanCorpus.Server.Abstractions/Rowles.LeanCorpus.Server.Abstractions.csproj",
+            "src/server/Rowles.LeanCorpus.Server.Core/Rowles.LeanCorpus.Server.Core.csproj",
+            "src/server/Rowles.LeanCorpus.Server.AspNetCore/Rowles.LeanCorpus.Server.AspNetCore.csproj",
+            "src/server/Rowles.LeanCorpus.Server.Grpc/Rowles.LeanCorpus.Server.Grpc.csproj",
+            "src/server/Rowles.LeanCorpus.Studio/Rowles.LeanCorpus.Studio.csproj",
+            "src/server/Rowles.LeanCorpus.Server.Local/Rowles.LeanCorpus.Server.Local.csproj",
+        ];
+
+        var failures = shippingProjects
+            .SelectMany(project => GetProjectReferences(project).Select(reference => (project, reference)))
+            .Where(static pair => IsTestOrDevelopmentProject(pair.reference))
+            .Select(static pair => $"{pair.project} -> {pair.reference}");
+
+        RuleAssert.Empty("Shipping projects must not reference test, benchmark, profiling or example projects:", failures);
+    }
+
+    [Fact]
+    public void LeanCorpus_must_remain_independent_of_optional_implementations()
+    {
+        var references = GetProjectReferences("src/core/Rowles.LeanCorpus/Rowles.LeanCorpus.csproj");
+
+        Assert.DoesNotContain(references, static reference => reference.Contains("Rowles.Text", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(references, static reference => reference.Contains("SourceGen", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(references, static reference => reference.Contains("Compression.", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(references, static reference => reference.Contains("Server", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void LeanCorpus_must_not_gain_runtime_package_dependencies()
+    {
+        XDocument project = LoadProject("src/core/Rowles.LeanCorpus/Rowles.LeanCorpus.csproj");
+        var runtimePackages = project.Descendants("PackageReference")
+            .Where(static reference => !string.Equals((string?)reference.Attribute("PrivateAssets"), "all", StringComparison.OrdinalIgnoreCase))
+            .Select(static reference => (string?)reference.Attribute("Include") ?? "unnamed package");
+
+        RuleAssert.Empty("LeanCorpus package references must be build or analyser-only with PrivateAssets=all:", runtimePackages);
+    }
+
+    [Fact]
+    public void Rowles_Text_must_not_gain_runtime_package_dependencies()
+    {
+        XDocument project = LoadProject("src/core/Rowles.Text/Rowles.Text.csproj");
+        var runtimePackages = project.Descendants("PackageReference")
+            .Where(static reference => !string.Equals((string?)reference.Attribute("PrivateAssets"), "all", StringComparison.OrdinalIgnoreCase))
+            .Select(static reference => (string?)reference.Attribute("Include") ?? "unnamed package");
+
+        RuleAssert.Empty("Rowles.Text package references must be build or analyser-only with PrivateAssets=all:", runtimePackages);
+    }
+
+    [Fact]
+    public void Compression_plugins_must_depend_on_Core_and_their_declared_implementations()
+    {
+        (string project, string implementation)[] plugins =
+        [
+            ("src/core/Rowles.LeanCorpus.Compression.LZ4/Rowles.LeanCorpus.Compression.LZ4.csproj", "K4os.Compression.LZ4"),
+            ("src/core/Rowles.LeanCorpus.Compression.Snappy/Rowles.LeanCorpus.Compression.Snappy.csproj", "Snappier"),
+            ("src/core/Rowles.LeanCorpus.Compression.Zstandard/Rowles.LeanCorpus.Compression.Zstandard.csproj", "ZstdSharp.Port"),
+        ];
+
+        foreach ((string projectPath, string implementation) in plugins)
+        {
+            XDocument project = LoadProject(projectPath);
+            Assert.Contains(GetProjectReferences(project), static reference => reference.Contains("Rowles.LeanCorpus", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(project.Descendants("PackageReference"), reference =>
+                string.Equals((string?)reference.Attribute("Include"), implementation, StringComparison.Ordinal));
+        }
+    }
+
+    [Fact]
+    public void Deliberately_AOT_compatible_projects_must_remain_so()
+    {
+        string[] projects =
+        [
+            "src/core/Rowles.LeanCorpus/Rowles.LeanCorpus.csproj",
+            "src/core/Rowles.Text/Rowles.Text.csproj",
+            "src/core/Rowles.LeanCorpus.Compression.LZ4/Rowles.LeanCorpus.Compression.LZ4.csproj",
+            "src/core/Rowles.LeanCorpus.Compression.Snappy/Rowles.LeanCorpus.Compression.Snappy.csproj",
+            "src/core/Rowles.LeanCorpus.Compression.Zstandard/Rowles.LeanCorpus.Compression.Zstandard.csproj",
+            "src/server/Rowles.LeanCorpus.Server.Abstractions/Rowles.LeanCorpus.Server.Abstractions.csproj",
+            "src/server/Rowles.LeanCorpus.Server.Core/Rowles.LeanCorpus.Server.Core.csproj",
+        ];
+
+        var failures = projects
+            .Where(project => !string.Equals(GetProperty(LoadProject(project), "IsAotCompatible"), "true", StringComparison.OrdinalIgnoreCase));
+
+        RuleAssert.Empty("These projects deliberately promise Native AOT compatibility:", failures);
+    }
+
+    [Fact]
     public void Project_wiring_must_keep_the_two_assemblies_independent()
     {
-        string root = FindRepositoryRoot();
-        XDocument leanCorpus = XDocument.Load(Path.Combine(
-            root, "src", "core", "Rowles.LeanCorpus", "Rowles.LeanCorpus.csproj"));
-        XDocument rowlesText = XDocument.Load(Path.Combine(
-            root, "src", "core", "Rowles.Text", "Rowles.Text.csproj"));
+        string root = RepositoryPaths.Root;
+        XDocument leanCorpus = LoadProject("src/core/Rowles.LeanCorpus/Rowles.LeanCorpus.csproj");
+        XDocument rowlesText = LoadProject("src/core/Rowles.Text/Rowles.Text.csproj");
 
         Assert.False(
             Directory.Exists(Path.Combine(root, "src", "core", "Rowles.LeanCorpus", "Analysis")),
@@ -57,17 +155,27 @@ public sealed class PackageBoundaryTests
         Assert.Contains("ROWLES_TEXT", constants, StringComparison.Ordinal);
     }
 
-    private static string FindRepositoryRoot()
-    {
-        DirectoryInfo? current = new(AppContext.BaseDirectory);
-        while (current is not null)
-        {
-            if (File.Exists(Path.Combine(current.FullName, "Rowles.LeanCorpus.slnx")))
-                return current.FullName;
+    private static XDocument LoadProject(string relativePath) => XDocument.Load(Path.Combine(
+        RepositoryPaths.Root, relativePath.Replace('/', Path.DirectorySeparatorChar)));
 
-            current = current.Parent;
-        }
+    private static string[] GetProjectReferences(string relativePath) => LoadProject(relativePath)
+        .Descendants("ProjectReference")
+        .Select(static element => (string?)element.Attribute("Include"))
+        .OfType<string>()
+        .ToArray();
 
-        throw new DirectoryNotFoundException("Could not locate the LeanCorpus repository root.");
-    }
+    private static string[] GetProjectReferences(XDocument project) => project.Descendants("ProjectReference")
+        .Select(static element => (string?)element.Attribute("Include"))
+        .OfType<string>()
+        .ToArray();
+
+    private static string? GetProperty(XDocument project, string name) => project.Descendants(name)
+        .Select(static element => element.Value.Trim())
+        .SingleOrDefault();
+
+    private static bool IsTestOrDevelopmentProject(string reference) =>
+        reference.Contains(".Tests", StringComparison.OrdinalIgnoreCase) ||
+        reference.Contains(".Benchmarks", StringComparison.OrdinalIgnoreCase) ||
+        reference.Contains(".Profiling", StringComparison.OrdinalIgnoreCase) ||
+        reference.Contains("examples", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/devops/Rowles.LeanCorpus.Tests.Architecture/PackageBoundaryTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Architecture/PackageBoundaryTests.cs
@@ -59,6 +59,7 @@ public sealed class PackageBoundaryTests
     {
         XDocument project = LoadProject("src/core/Rowles.LeanCorpus/Rowles.LeanCorpus.csproj");
         var runtimePackages = project.Descendants("PackageReference")
+            .Where(IsRuntimePackageReference)
             .Select(static reference => (string?)reference.Attribute("Include") ?? "unnamed package");
 
         RuleAssert.Empty("LeanCorpus must not gain direct package references:", runtimePackages);
@@ -69,6 +70,7 @@ public sealed class PackageBoundaryTests
     {
         XDocument project = LoadProject("src/core/Rowles.Text/Rowles.Text.csproj");
         var runtimePackages = project.Descendants("PackageReference")
+            .Where(IsRuntimePackageReference)
             .Select(static reference => (string?)reference.Attribute("Include") ?? "unnamed package");
 
         RuleAssert.Empty("Rowles.Text must not gain direct package references:", runtimePackages);
@@ -181,10 +183,34 @@ public sealed class PackageBoundaryTests
     private static bool IsTestOrDevelopmentProject(string projectPath, string reference)
     {
         string target = ToRepositoryRelativePath(projectPath, reference);
-        return target.StartsWith("src/devops/", StringComparison.OrdinalIgnoreCase) &&
-               !string.Equals(target, "src/devops/Rowles.LeanCorpus.Cli/Rowles.LeanCorpus.Cli.csproj", StringComparison.OrdinalIgnoreCase) ||
+        string filename = Path.GetFileNameWithoutExtension(target);
+        return filename.Contains(".Tests", StringComparison.OrdinalIgnoreCase) ||
+               filename.Contains(".Benchmarks", StringComparison.OrdinalIgnoreCase) ||
+               filename.Contains(".Profiling", StringComparison.OrdinalIgnoreCase) ||
                target.StartsWith("src/examples/", StringComparison.OrdinalIgnoreCase);
     }
+
+    private static bool IsRuntimePackageReference(XElement packageReference) =>
+        !IsBuildOrAnalyserOnlyPackageReference(packageReference);
+
+    private static bool IsBuildOrAnalyserOnlyPackageReference(XElement packageReference)
+    {
+        if (!string.Equals(GetItemMetadata(packageReference, "PrivateAssets"), "all", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        string? includeAssets = GetItemMetadata(packageReference, "IncludeAssets");
+        if (string.IsNullOrWhiteSpace(includeAssets))
+            return false;
+
+        return includeAssets.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .All(static asset => asset.Equals("build", StringComparison.OrdinalIgnoreCase) ||
+                                 asset.Equals("buildMultitargeting", StringComparison.OrdinalIgnoreCase) ||
+                                 asset.Equals("buildTransitive", StringComparison.OrdinalIgnoreCase) ||
+                                 asset.Equals("analyzers", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string? GetItemMetadata(XElement item, string name) =>
+        ((string?)item.Attribute(name) ?? item.Element(name)?.Value)?.Trim();
 
     private static string ToRepositoryRelativePath(string projectPath, string reference)
     {

--- a/src/devops/Rowles.LeanCorpus.Tests.Architecture/ServerLayeringTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Architecture/ServerLayeringTests.cs
@@ -22,15 +22,22 @@ public sealed class ServerLayeringTests
         AssertDoesNotReference("Rowles.LeanCorpus.Server.Grpc", "Rowles.LeanCorpus.Studio");
     }
 
-    [Fact]
-    public void Server_Local_remains_the_composition_root()
+    [Theory]
+    [InlineData("Rowles.LeanCorpus.Server.Abstractions")]
+    [InlineData("Rowles.LeanCorpus.Server.Core")]
+    public void Reusable_Server_layers_must_not_declare_transport_dependencies(string project)
     {
-        string[] references = GetProjectReferences("Rowles.LeanCorpus.Server.Local");
+        XDocument document = LoadProject(project);
 
-        Assert.Contains(references, static reference => reference.Contains("Rowles.LeanCorpus.Server.Core", StringComparison.OrdinalIgnoreCase));
-        Assert.Contains(references, static reference => reference.Contains("Rowles.LeanCorpus.Server.AspNetCore", StringComparison.OrdinalIgnoreCase));
-        Assert.Contains(references, static reference => reference.Contains("Rowles.LeanCorpus.Server.Grpc", StringComparison.OrdinalIgnoreCase));
-        Assert.Contains(references, static reference => reference.Contains("Rowles.LeanCorpus.Studio", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(document.Descendants("FrameworkReference"), static reference =>
+            string.Equals((string?)reference.Attribute("Include"), "Microsoft.AspNetCore.App", StringComparison.Ordinal));
+        Assert.DoesNotContain(document.Descendants("PackageReference"), static reference =>
+        {
+            string? package = (string?)reference.Attribute("Include");
+            return package is not null && (package.StartsWith("Microsoft.AspNetCore.", StringComparison.Ordinal) ||
+                                           package.StartsWith("Grpc.", StringComparison.Ordinal) ||
+                                           package.StartsWith("Google.Protobuf", StringComparison.Ordinal));
+        });
     }
 
     private static void AssertDoesNotReference(string project, params string[] forbiddenProjects)
@@ -40,10 +47,12 @@ public sealed class ServerLayeringTests
             Assert.DoesNotContain(references, reference => reference.Contains(forbidden, StringComparison.OrdinalIgnoreCase));
     }
 
-    private static string[] GetProjectReferences(string project) => XDocument.Load(RepositoryPaths.FromRoot(
-            "src", "server", project, $"{project}.csproj"))
+    private static string[] GetProjectReferences(string project) => LoadProject(project)
         .Descendants("ProjectReference")
         .Select(static reference => (string?)reference.Attribute("Include"))
         .OfType<string>()
         .ToArray();
+
+    private static XDocument LoadProject(string project) => XDocument.Load(RepositoryPaths.FromRoot(
+        "src", "server", project, $"{project}.csproj"));
 }

--- a/src/devops/Rowles.LeanCorpus.Tests.Architecture/ServerLayeringTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Architecture/ServerLayeringTests.cs
@@ -21,25 +21,6 @@ public sealed class ServerLayeringTests
         AssertDoesNotReference("Rowles.LeanCorpus.Server.AspNetCore", "Rowles.LeanCorpus.Studio");
         AssertDoesNotReference("Rowles.LeanCorpus.Server.Grpc", "Rowles.LeanCorpus.Studio");
     }
-
-    [Theory]
-    [InlineData("Rowles.LeanCorpus.Server.Abstractions")]
-    [InlineData("Rowles.LeanCorpus.Server.Core")]
-    public void Reusable_Server_layers_must_not_declare_transport_dependencies(string project)
-    {
-        XDocument document = LoadProject(project);
-
-        Assert.DoesNotContain(document.Descendants("FrameworkReference"), static reference =>
-            string.Equals((string?)reference.Attribute("Include"), "Microsoft.AspNetCore.App", StringComparison.Ordinal));
-        Assert.DoesNotContain(document.Descendants("PackageReference"), static reference =>
-        {
-            string? package = (string?)reference.Attribute("Include");
-            return package is not null && (package.StartsWith("Microsoft.AspNetCore.", StringComparison.Ordinal) ||
-                                           package.StartsWith("Grpc.", StringComparison.Ordinal) ||
-                                           package.StartsWith("Google.Protobuf", StringComparison.Ordinal));
-        });
-    }
-
     private static void AssertDoesNotReference(string project, params string[] forbiddenProjects)
     {
         string[] references = GetProjectReferences(project);

--- a/src/devops/Rowles.LeanCorpus.Tests.Architecture/ServerLayeringTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Architecture/ServerLayeringTests.cs
@@ -1,0 +1,49 @@
+using System.Xml.Linq;
+using Rowles.LeanCorpus.Tests.Architecture.Infrastructure;
+
+namespace Rowles.LeanCorpus.Tests.Architecture;
+
+public sealed class ServerLayeringTests
+{
+    [Fact]
+    public void Server_Abstractions_must_not_reference_concrete_layers() =>
+        AssertDoesNotReference("Rowles.LeanCorpus.Server.Abstractions", "Rowles.LeanCorpus.Server.Core", "Rowles.LeanCorpus.Server.AspNetCore", "Rowles.LeanCorpus.Server.Grpc", "Rowles.LeanCorpus.Studio", "Rowles.LeanCorpus.Server.Local");
+
+    [Fact]
+    public void Server_Core_must_not_reference_transports_or_composition_layers() =>
+        AssertDoesNotReference("Rowles.LeanCorpus.Server.Core", "Rowles.LeanCorpus.Server.AspNetCore", "Rowles.LeanCorpus.Server.Grpc", "Rowles.LeanCorpus.Studio", "Rowles.LeanCorpus.Server.Local");
+
+    [Fact]
+    public void Reusable_Server_layers_must_not_reference_Studio()
+    {
+        AssertDoesNotReference("Rowles.LeanCorpus.Server.Abstractions", "Rowles.LeanCorpus.Studio");
+        AssertDoesNotReference("Rowles.LeanCorpus.Server.Core", "Rowles.LeanCorpus.Studio");
+        AssertDoesNotReference("Rowles.LeanCorpus.Server.AspNetCore", "Rowles.LeanCorpus.Studio");
+        AssertDoesNotReference("Rowles.LeanCorpus.Server.Grpc", "Rowles.LeanCorpus.Studio");
+    }
+
+    [Fact]
+    public void Server_Local_remains_the_composition_root()
+    {
+        string[] references = GetProjectReferences("Rowles.LeanCorpus.Server.Local");
+
+        Assert.Contains(references, static reference => reference.Contains("Rowles.LeanCorpus.Server.Core", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(references, static reference => reference.Contains("Rowles.LeanCorpus.Server.AspNetCore", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(references, static reference => reference.Contains("Rowles.LeanCorpus.Server.Grpc", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(references, static reference => reference.Contains("Rowles.LeanCorpus.Studio", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static void AssertDoesNotReference(string project, params string[] forbiddenProjects)
+    {
+        string[] references = GetProjectReferences(project);
+        foreach (string forbidden in forbiddenProjects)
+            Assert.DoesNotContain(references, reference => reference.Contains(forbidden, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string[] GetProjectReferences(string project) => XDocument.Load(RepositoryPaths.FromRoot(
+            "src", "server", project, $"{project}.csproj"))
+        .Descendants("ProjectReference")
+        .Select(static reference => (string?)reference.Attribute("Include"))
+        .OfType<string>()
+        .ToArray();
+}

--- a/src/devops/Rowles.LeanCorpus.Tests.Architecture/SourceGenBoundaryTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Architecture/SourceGenBoundaryTests.cs
@@ -21,6 +21,16 @@ public sealed class SourceGenBoundaryTests
         Assert.DoesNotContain(references, static reference => reference.Contains("Rowles.LeanCorpus", StringComparison.OrdinalIgnoreCase));
         Assert.DoesNotContain(references, static reference => reference.Contains("Rowles.Text", StringComparison.OrdinalIgnoreCase));
         Assert.DoesNotContain(references, static reference => reference.Contains("Server", StringComparison.OrdinalIgnoreCase));
+
+        var packages = project.Descendants("PackageReference")
+            .Select(static reference => (string?)reference.Attribute("Include"))
+            .OfType<string>();
+        Assert.DoesNotContain(packages, static package => string.Equals(package, "Rowles.LeanCorpus", StringComparison.Ordinal));
+
+        var assemblyReferences = project.Descendants("Reference")
+            .Select(static reference => (string?)reference.Attribute("Include"))
+            .OfType<string>();
+        Assert.DoesNotContain(assemblyReferences, static reference => reference.StartsWith("Rowles.LeanCorpus", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/src/devops/Rowles.LeanCorpus.Tests.Architecture/SourceGenBoundaryTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Architecture/SourceGenBoundaryTests.cs
@@ -22,10 +22,12 @@ public sealed class SourceGenBoundaryTests
         Assert.DoesNotContain(references, static reference => reference.Contains("Rowles.Text", StringComparison.OrdinalIgnoreCase));
         Assert.DoesNotContain(references, static reference => reference.Contains("Server", StringComparison.OrdinalIgnoreCase));
 
-        var packages = project.Descendants("PackageReference")
+        string[] packages = project.Descendants("PackageReference")
             .Select(static reference => (string?)reference.Attribute("Include"))
-            .OfType<string>();
-        Assert.DoesNotContain(packages, static package => string.Equals(package, "Rowles.LeanCorpus", StringComparison.Ordinal));
+            .OfType<string>()
+            .ToArray();
+        Assert.Single(packages);
+        Assert.Equal("Microsoft.CodeAnalysis.CSharp", packages[0], ignoreCase: true);
 
         var assemblyReferences = project.Descendants("Reference")
             .Select(static reference => (string?)reference.Attribute("Include"))
@@ -38,7 +40,7 @@ public sealed class SourceGenBoundaryTests
     {
         XDocument project = LoadProject();
         XElement? roslyn = project.Descendants("PackageReference")
-            .SingleOrDefault(static reference => string.Equals((string?)reference.Attribute("Include"), "Microsoft.CodeAnalysis.CSharp", StringComparison.Ordinal));
+            .SingleOrDefault(static reference => string.Equals((string?)reference.Attribute("Include"), "Microsoft.CodeAnalysis.CSharp", StringComparison.OrdinalIgnoreCase));
         Assert.NotNull(roslyn);
         Assert.Equal("all", (string?)roslyn.Attribute("PrivateAssets"), ignoreCase: true);
 

--- a/src/devops/Rowles.LeanCorpus.Tests.Architecture/SourceGenBoundaryTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Architecture/SourceGenBoundaryTests.cs
@@ -1,0 +1,47 @@
+using System.Xml.Linq;
+using Rowles.LeanCorpus.Tests.Architecture.Infrastructure;
+
+namespace Rowles.LeanCorpus.Tests.Architecture;
+
+public sealed class SourceGenBoundaryTests
+{
+    [Fact]
+    public void SourceGen_must_remain_an_isolated_Roslyn_component()
+    {
+        XDocument project = LoadProject();
+
+        Assert.Equal("netstandard2.0", GetProperty(project, "TargetFramework"));
+        Assert.Equal("true", GetProperty(project, "IsRoslynComponent"));
+        Assert.Equal("false", GetProperty(project, "IncludeBuildOutput"));
+        Assert.Equal("true", GetProperty(project, "DevelopmentDependency"));
+
+        var references = project.Descendants("ProjectReference")
+            .Select(static reference => (string?)reference.Attribute("Include"))
+            .OfType<string>();
+        Assert.DoesNotContain(references, static reference => reference.Contains("Rowles.LeanCorpus", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(references, static reference => reference.Contains("Rowles.Text", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(references, static reference => reference.Contains("Server", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void SourceGen_must_package_its_analyser_assembly_correctly()
+    {
+        XDocument project = LoadProject();
+        XElement? roslyn = project.Descendants("PackageReference")
+            .SingleOrDefault(static reference => string.Equals((string?)reference.Attribute("Include"), "Microsoft.CodeAnalysis.CSharp", StringComparison.Ordinal));
+        Assert.NotNull(roslyn);
+        Assert.Equal("all", (string?)roslyn.Attribute("PrivateAssets"), ignoreCase: true);
+
+        Assert.Contains(project.Descendants("None"), static item =>
+            string.Equals(((string?)item.Attribute("Include"))?.Replace('\\', '/'), "$(OutputPath)/$(AssemblyName).dll", StringComparison.Ordinal) &&
+            string.Equals((string?)item.Attribute("Pack"), "true", StringComparison.OrdinalIgnoreCase) &&
+            string.Equals((string?)item.Attribute("PackagePath"), "analyzers/dotnet/cs", StringComparison.Ordinal));
+    }
+
+    private static XDocument LoadProject() => XDocument.Load(RepositoryPaths.FromRoot(
+        "src", "core", "Rowles.LeanCorpus.SourceGen", "Rowles.LeanCorpus.SourceGen.csproj"));
+
+    private static string? GetProperty(XDocument project, string name) => project.Descendants(name)
+        .Select(static property => property.Value.Trim())
+        .SingleOrDefault();
+}


### PR DESCRIPTION
Expand `Rowles.LeanCorpus.Tests.Architecture` to protect the important architectural boundaries of the current repository without turning the test project into another framework.