### PR TITLE
Issue #86 Investigate Windows CI handle-lifetime stress failures

### DIFF
--- a/changelog/unreleased.md
+++ b/changelog/unreleased.md
@@ -4,10 +4,10 @@
 
 ### Fixed
 
-- Cleared pooled stored-field writer scratch before use so previous search activity cannot silently omit fields from newly written segments.
-- Released the writer lock when incompatible index metadata aborts `IndexWriter` construction, preventing Windows test-directory cleanup failures.
-- Synchronised merge-throttling segment inspection with background merge publication without nesting writer and merge locks, and made background-refresh coverage scheduler-friendly under stress execution.
-- Added structured terminal file-move and cleanup diagnostics, including paths, HRESULT, retry count, and elapsed time, and deterministically disposed the merge regression directory.
+- Cleared pooled stored-field writer scratch before use so previous search activity cannot silently omit fields from newly written segments. (f58ac6c44)
+- Released the writer lock when incompatible index metadata aborts `IndexWriter` construction, preventing Windows test-directory cleanup failures. (60b6735ea, #86)
+- Synchronised merge-throttling segment inspection with background merge publication without nesting writer and merge locks, and made background-refresh coverage scheduler-friendly under stress execution. (cc3dc2aa5, 34a3c69bd, #86)
+- Added structured terminal file-move and cleanup diagnostics, including paths, HRESULT, retry count, and elapsed time, and deterministically disposed the merge regression directory. (016a50aa6, #86)
 
 ### Removed
 

--- a/changelog/unreleased.md
+++ b/changelog/unreleased.md
@@ -1,24 +1,19 @@
 ### Added
 
-* Added unified DevOps run manifests, xUnit-correlated test telemetry, runtime diagnostics, CTRF and GitHub Actions reporting, and safe `clean` and package-manifest workflows under `artifacts/`.
-
 ### Changed
-
-* Strengthened architecture tests for exact package and plugin isolation, Server transport boundaries, filesystem ownership, and Native AOT runtime IL-generation boundaries.
-* Bumped the LeanCorpus package to 3.1.1 for the stored-field persistence fix.
-* Consolidated build, test, coverage, benchmark, diagnostic and documentation output under the SDK artefact root; normal benchmark runs now cover Core, Rowles.Text and compression in one provenance-scoped run, and Native AOT smoke tests use the stable xUnit 4 MTP v2 stack.
 
 ### Fixed
 
-* Cleared pooled stored-field writer scratch before use so previous search activity cannot silently omit fields from newly written segments.
-* Isolated stress-test metric listeners and statistics temporary-file checks from concurrent test activity.
-* Hardened Windows lifecycle tests and made repeated MTP test diagnostics aggregate by semantic test identity across executions.
-* Fixed CI-prepared test executable discovery, empty-telemetry reporting and central-output metadata tests.
-* Fixed benchmark report schema collisions, result-based benchmark exit codes, coverage status propagation, current-commit documentation coverage, and interrupted artefact-run finalisation.
-* Hardened benchmark documentation evidence selection, dirty-worktree coverage provenance, shared coverage/test run identity, best-effort test telemetry, and Windows stress-test diagnostics.
+- Cleared pooled stored-field writer scratch before use so previous search activity cannot silently omit fields from newly written segments.
+- Released the writer lock when incompatible index metadata aborts `IndexWriter` construction, preventing Windows test-directory cleanup failures.
 
 ### Removed
 
 ### Deprecated
 
 ### Security
+
+<!--
+Only edits to the core libraries get a changelog item.
+DevOps, tests, benchmarks, anything else does not.
+-->

--- a/changelog/unreleased.md
+++ b/changelog/unreleased.md
@@ -6,6 +6,7 @@
 
 - Cleared pooled stored-field writer scratch before use so previous search activity cannot silently omit fields from newly written segments.
 - Released the writer lock when incompatible index metadata aborts `IndexWriter` construction, preventing Windows test-directory cleanup failures.
+- Synchronised merge-throttling segment inspection with background merge publication and made background-refresh coverage scheduler-friendly under stress execution.
 
 ### Removed
 

--- a/changelog/unreleased.md
+++ b/changelog/unreleased.md
@@ -6,7 +6,7 @@
 
 - Cleared pooled stored-field writer scratch before use so previous search activity cannot silently omit fields from newly written segments.
 - Released the writer lock when incompatible index metadata aborts `IndexWriter` construction, preventing Windows test-directory cleanup failures.
-- Synchronised merge-throttling segment inspection with background merge publication and made background-refresh coverage scheduler-friendly under stress execution.
+- Synchronised merge-throttling segment inspection with background merge publication without nesting writer and merge locks, and made background-refresh coverage scheduler-friendly under stress execution.
 - Added structured terminal file-move and cleanup diagnostics, including paths, HRESULT, retry count, and elapsed time, and deterministically disposed the merge regression directory.
 
 ### Removed

--- a/changelog/unreleased.md
+++ b/changelog/unreleased.md
@@ -7,6 +7,7 @@
 - Cleared pooled stored-field writer scratch before use so previous search activity cannot silently omit fields from newly written segments.
 - Released the writer lock when incompatible index metadata aborts `IndexWriter` construction, preventing Windows test-directory cleanup failures.
 - Synchronised merge-throttling segment inspection with background merge publication and made background-refresh coverage scheduler-friendly under stress execution.
+- Added structured terminal file-move and cleanup diagnostics, including paths, HRESULT, retry count, and elapsed time, and deterministically disposed the merge regression directory.
 
 ### Removed
 

--- a/docs/changelog/unreleased.md
+++ b/docs/changelog/unreleased.md
@@ -4,10 +4,10 @@
 
 ### Fixed
 
-- Cleared pooled stored-field writer scratch before use so previous search activity cannot silently omit fields from newly written segments.
-- Released the writer lock when incompatible index metadata aborts `IndexWriter` construction, preventing Windows test-directory cleanup failures.
-- Synchronised merge-throttling segment inspection with background merge publication without nesting writer and merge locks, and made background-refresh coverage scheduler-friendly under stress execution.
-- Added structured terminal file-move and cleanup diagnostics, including paths, HRESULT, retry count, and elapsed time, and deterministically disposed the merge regression directory.
+- Cleared pooled stored-field writer scratch before use so previous search activity cannot silently omit fields from newly written segments. (f58ac6c44)
+- Released the writer lock when incompatible index metadata aborts `IndexWriter` construction, preventing Windows test-directory cleanup failures. (60b6735ea, #86)
+- Synchronised merge-throttling segment inspection with background merge publication without nesting writer and merge locks, and made background-refresh coverage scheduler-friendly under stress execution. (cc3dc2aa5, 34a3c69bd, #86)
+- Added structured terminal file-move and cleanup diagnostics, including paths, HRESULT, retry count, and elapsed time, and deterministically disposed the merge regression directory. (016a50aa6, #86)
 
 ### Removed
 

--- a/docs/changelog/unreleased.md
+++ b/docs/changelog/unreleased.md
@@ -1,24 +1,19 @@
 ### Added
 
-* Added unified DevOps run manifests, xUnit-correlated test telemetry, runtime diagnostics, CTRF and GitHub Actions reporting, and safe `clean` and package-manifest workflows under `artifacts/`.
-
 ### Changed
-
-* Strengthened architecture tests for exact package and plugin isolation, Server transport boundaries, filesystem ownership, and Native AOT runtime IL-generation boundaries.
-* Bumped the LeanCorpus package to 3.1.1 for the stored-field persistence fix.
-* Consolidated build, test, coverage, benchmark, diagnostic and documentation output under the SDK artefact root; normal benchmark runs now cover Core, Rowles.Text and compression in one provenance-scoped run, and Native AOT smoke tests use the stable xUnit 4 MTP v2 stack.
 
 ### Fixed
 
-* Cleared pooled stored-field writer scratch before use so previous search activity cannot silently omit fields from newly written segments.
-* Isolated stress-test metric listeners and statistics temporary-file checks from concurrent test activity.
-* Hardened Windows lifecycle tests and made repeated MTP test diagnostics aggregate by semantic test identity across executions.
-* Fixed CI-prepared test executable discovery, empty-telemetry reporting and central-output metadata tests.
-* Fixed benchmark report schema collisions, result-based benchmark exit codes, coverage status propagation, current-commit documentation coverage, and interrupted artefact-run finalisation.
-* Hardened benchmark documentation evidence selection, dirty-worktree coverage provenance, shared coverage/test run identity, best-effort test telemetry, and Windows stress-test diagnostics.
+- Cleared pooled stored-field writer scratch before use so previous search activity cannot silently omit fields from newly written segments.
+- Released the writer lock when incompatible index metadata aborts `IndexWriter` construction, preventing Windows test-directory cleanup failures.
 
 ### Removed
 
 ### Deprecated
 
 ### Security
+
+<!--
+Only edits to the core libraries get a changelog item.
+DevOps, tests, benchmarks, anything else does not.
+-->

--- a/docs/changelog/unreleased.md
+++ b/docs/changelog/unreleased.md
@@ -6,6 +6,7 @@
 
 - Cleared pooled stored-field writer scratch before use so previous search activity cannot silently omit fields from newly written segments.
 - Released the writer lock when incompatible index metadata aborts `IndexWriter` construction, preventing Windows test-directory cleanup failures.
+- Synchronised merge-throttling segment inspection with background merge publication and made background-refresh coverage scheduler-friendly under stress execution.
 
 ### Removed
 

--- a/docs/changelog/unreleased.md
+++ b/docs/changelog/unreleased.md
@@ -6,7 +6,7 @@
 
 - Cleared pooled stored-field writer scratch before use so previous search activity cannot silently omit fields from newly written segments.
 - Released the writer lock when incompatible index metadata aborts `IndexWriter` construction, preventing Windows test-directory cleanup failures.
-- Synchronised merge-throttling segment inspection with background merge publication and made background-refresh coverage scheduler-friendly under stress execution.
+- Synchronised merge-throttling segment inspection with background merge publication without nesting writer and merge locks, and made background-refresh coverage scheduler-friendly under stress execution.
 - Added structured terminal file-move and cleanup diagnostics, including paths, HRESULT, retry count, and elapsed time, and deterministically disposed the merge regression directory.
 
 ### Removed

--- a/docs/changelog/unreleased.md
+++ b/docs/changelog/unreleased.md
@@ -7,6 +7,7 @@
 - Cleared pooled stored-field writer scratch before use so previous search activity cannot silently omit fields from newly written segments.
 - Released the writer lock when incompatible index metadata aborts `IndexWriter` construction, preventing Windows test-directory cleanup failures.
 - Synchronised merge-throttling segment inspection with background merge publication and made background-refresh coverage scheduler-friendly under stress execution.
+- Added structured terminal file-move and cleanup diagnostics, including paths, HRESULT, retry count, and elapsed time, and deterministically disposed the merge regression directory.
 
 ### Removed
 

--- a/src/core/Rowles.LeanCorpus/Diagnostics/LeanCorpusActivitySource.cs
+++ b/src/core/Rowles.LeanCorpus/Diagnostics/LeanCorpusActivitySource.cs
@@ -47,4 +47,35 @@ internal static class LeanCorpusActivitySource
                 }));
         }
     }
+
+    /// <summary>Records a terminal filesystem operation failure without changing its exception.</summary>
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    internal static void TraceFileSystemFailure(
+        Exception exception,
+        string operation,
+        string path,
+        string? destinationPath,
+        int retryCount,
+        TimeSpan elapsed)
+    {
+        Debug.WriteLine(
+            $"LeanCorpus filesystem failure: operation={operation}, path={path}, destination={destinationPath}, " +
+            $"hresult=0x{exception.HResult:X8}, retries={retryCount}, elapsed_ms={elapsed.TotalMilliseconds:F3}: {exception.Message}");
+
+        if (Activity.Current is { } activity)
+        {
+            activity.AddEvent(new ActivityEvent(
+                "filesystem.operation.failed",
+                tags: new ActivityTagsCollection
+                {
+                    { "filesystem.operation", operation },
+                    { "filesystem.path", path },
+                    { "filesystem.destination_path", destinationPath },
+                    { "exception.type", exception.GetType().Name },
+                    { "exception.hresult", exception.HResult },
+                    { "retry.count", retryCount },
+                    { "elapsed.ms", elapsed.TotalMilliseconds }
+                }));
+        }
+    }
 }

--- a/src/core/Rowles.LeanCorpus/Index/Indexer/IndexWriter.cs
+++ b/src/core/Rowles.LeanCorpus/Index/Indexer/IndexWriter.cs
@@ -728,29 +728,35 @@ public sealed partial class IndexWriter : IDisposable
 
     internal bool ShouldThrottleForMerge()
     {
+        SegmentInfo[] committedSegments;
+        lock (_writeLock)
+        {
+            if (_config.MergeThrottleSegments > 0 &&
+                _committedSegments.Count >= _config.MergeThrottleSegments)
+                return true;
+
+            if (_config.MaxPendingMergeBytes <= 0)
+                return false;
+
+            committedSegments = _committedSegments.ToArray();
+        }
+
+        HashSet<string> reservedMergeSegments;
         lock (_mergeLock)
         {
-            // Background merge publication and DWPT flush publication both mutate
-            // _committedSegments under _writeLock. Keep the merge lock outermost,
-            // matching MergeScheduler's lock order.
-            lock (_writeLock)
-            {
-                if (_config.MergeThrottleSegments > 0 &&
-                    _committedSegments.Count >= _config.MergeThrottleSegments)
-                    return true;
+            if (_reservedMergeSegments.Count == 0)
+                return false;
 
-                if (_config.MaxPendingMergeBytes <= 0 || _reservedMergeSegments.Count == 0)
-                    return false;
-
-                long pendingBytes = 0;
-                foreach (var segment in _committedSegments)
-                {
-                    if (_reservedMergeSegments.Contains(segment.SegmentId))
-                        pendingBytes += segment.TotalBytes;
-                }
-                return pendingBytes >= _config.MaxPendingMergeBytes;
-            }
+            reservedMergeSegments = new HashSet<string>(_reservedMergeSegments, StringComparer.Ordinal);
         }
+
+        long pendingBytes = 0;
+        foreach (var segment in committedSegments)
+        {
+            if (reservedMergeSegments.Contains(segment.SegmentId))
+                pendingBytes += segment.TotalBytes;
+        }
+        return pendingBytes >= _config.MaxPendingMergeBytes;
     }
 
     internal void ThrottleMerge()

--- a/src/core/Rowles.LeanCorpus/Index/Indexer/IndexWriter.cs
+++ b/src/core/Rowles.LeanCorpus/Index/Indexer/IndexWriter.cs
@@ -130,24 +130,39 @@ public sealed partial class IndexWriter : IDisposable
 
         // Acquire exclusive write lock for this directory
         var lockPath = Path.Combine(directory.DirectoryPath, "write.lock");
+        Stream writeLockFile;
         try
         {
-            _writeLockFile = FileOpenRetry.Open(lockPath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None);
+            writeLockFile = FileOpenRetry.Open(lockPath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None);
         }
         catch (IOException)
         {
             throw new WriteLockException(directory.DirectoryPath);
         }
 
-        // Initialize backpressure semaphore if MaxQueuedDocs > 0
-        if (config.MaxQueuedDocs > 0)
-            _backpressureSemaphore = new SemaphoreSlim(config.MaxQueuedDocs, config.MaxQueuedDocs);
-        if (config.MaxConcurrentFlushes > 1)
-            _flushSemaphore = new SemaphoreSlim(config.MaxConcurrentFlushes, config.MaxConcurrentFlushes);
+        try
+        {
+            _writeLockFile = writeLockFile;
 
-        // Load existing commit state if present
-        CommitManager.LoadLatestCommit(this);
-        DwptManager.InitialiseDwptPool(this);
+            // Initialize backpressure semaphore if MaxQueuedDocs > 0
+            if (config.MaxQueuedDocs > 0)
+                _backpressureSemaphore = new SemaphoreSlim(config.MaxQueuedDocs, config.MaxQueuedDocs);
+            if (config.MaxConcurrentFlushes > 1)
+                _flushSemaphore = new SemaphoreSlim(config.MaxConcurrentFlushes, config.MaxConcurrentFlushes);
+
+            // Load existing commit state if present
+            CommitManager.LoadLatestCommit(this);
+            DwptManager.InitialiseDwptPool(this);
+        }
+        catch
+        {
+            _backpressureSemaphore?.Dispose();
+            _flushSemaphore?.Dispose();
+            writeLockFile.Dispose();
+            try { FileOpenRetry.Delete(lockPath); }
+            catch (Exception ex) { Diagnostics.LeanCorpusActivitySource.TraceSwallowed(ex, "constructor write-lock file delete"); }
+            throw;
+        }
 
         // The asynchronous write channel is created on first use. Most writers use
         // the synchronous API and must not depend on a thread-pool worker at disposal.

--- a/src/core/Rowles.LeanCorpus/Index/Indexer/IndexWriter.cs
+++ b/src/core/Rowles.LeanCorpus/Index/Indexer/IndexWriter.cs
@@ -728,22 +728,28 @@ public sealed partial class IndexWriter : IDisposable
 
     internal bool ShouldThrottleForMerge()
     {
-        if (_config.MergeThrottleSegments > 0 &&
-            _committedSegments.Count >= _config.MergeThrottleSegments)
-            return true;
-
         lock (_mergeLock)
         {
-            if (_config.MaxPendingMergeBytes <= 0 || _reservedMergeSegments.Count == 0)
-                return false;
-
-            long pendingBytes = 0;
-            foreach (var segment in _committedSegments)
+            // Background merge publication and DWPT flush publication both mutate
+            // _committedSegments under _writeLock. Keep the merge lock outermost,
+            // matching MergeScheduler's lock order.
+            lock (_writeLock)
             {
-                if (_reservedMergeSegments.Contains(segment.SegmentId))
-                    pendingBytes += segment.TotalBytes;
+                if (_config.MergeThrottleSegments > 0 &&
+                    _committedSegments.Count >= _config.MergeThrottleSegments)
+                    return true;
+
+                if (_config.MaxPendingMergeBytes <= 0 || _reservedMergeSegments.Count == 0)
+                    return false;
+
+                long pendingBytes = 0;
+                foreach (var segment in _committedSegments)
+                {
+                    if (_reservedMergeSegments.Contains(segment.SegmentId))
+                        pendingBytes += segment.TotalBytes;
+                }
+                return pendingBytes >= _config.MaxPendingMergeBytes;
             }
-            return pendingBytes >= _config.MaxPendingMergeBytes;
         }
     }
 

--- a/src/core/Rowles.LeanCorpus/Store/FileOpenRetry.cs
+++ b/src/core/Rowles.LeanCorpus/Store/FileOpenRetry.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
 
@@ -151,6 +152,7 @@ internal static class FileOpenRetry
     internal static void Delete(string path)
     {
         int retries = TransientMaxRetries;
+        long startedAt = Stopwatch.GetTimestamp();
         while (true)
         {
             try
@@ -162,6 +164,12 @@ internal static class FileOpenRetry
             catch (Exception ex) when (ShouldRetry(ex, ref retries)) { DelayBeforeRetry(); }
             catch (FileNotFoundException) { return; }
             catch (DirectoryNotFoundException) { return; }
+            catch (Exception ex)
+            {
+                Diagnostics.LeanCorpusActivitySource.TraceFileSystemFailure(
+                    ex, "file.delete", path, null, TransientMaxRetries - retries, Stopwatch.GetElapsedTime(startedAt));
+                throw;
+            }
         }
     }
 
@@ -171,6 +179,7 @@ internal static class FileOpenRetry
     internal static DirtyFileTracker.DirtyFile Move(string sourcePath, string destPath, bool overwrite = false)
     {
         int retries = TransientMaxRetries;
+        long startedAt = Stopwatch.GetTimestamp();
         while (true)
         {
             try
@@ -179,6 +188,12 @@ internal static class FileOpenRetry
                 return DirtyFileTracker.Move(sourcePath, destPath);
             }
             catch (Exception ex) when (ShouldRetry(ex, ref retries)) { DelayBeforeRetry(); }
+            catch (Exception ex)
+            {
+                Diagnostics.LeanCorpusActivitySource.TraceFileSystemFailure(
+                    ex, "file.move", sourcePath, destPath, TransientMaxRetries - retries, Stopwatch.GetElapsedTime(startedAt));
+                throw;
+            }
         }
     }
 

--- a/src/core/Rowles.LeanCorpus/Store/IndexAtomicFileWriter.cs
+++ b/src/core/Rowles.LeanCorpus/Store/IndexAtomicFileWriter.cs
@@ -20,9 +20,6 @@ internal static class IndexAtomicFileWriter
         });
     }
 
-    private const int MoveRetries = 5;
-    private const int MoveRetryDelayMs = 10;
-
     public static void Write(string path, bool durable, Action<Stream> write)
         => Write(path, durable, syncDirectory: true, write);
 

--- a/src/devops/Rowles.LeanCorpus.Tests.Core/Diagnostics/Unit/ActivitySourceTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Core/Diagnostics/Unit/ActivitySourceTests.cs
@@ -60,6 +60,31 @@ public sealed class ActivitySourceTests : IDisposable
     private IEnumerable<Activity> Scoped(Activity scope)
         => _captured.Where(a => a.RootId == scope.RootId && a.Source.Name == SourceName);
 
+    /// <summary>Verifies terminal filesystem failures retain actionable operation details.</summary>
+    [Fact(DisplayName = "Diagnostics: Filesystem Failure Includes Operation Details")]
+    public void FileSystemFailure_IncludesOperationDetails()
+    {
+        using var scope = StartScope();
+        var exception = new IOException("sharing violation", unchecked((int)0x80070020));
+
+        LeanCorpusActivitySource.TraceFileSystemFailure(
+            exception,
+            "file.move",
+            @"C:\index\segments.tmp",
+            @"C:\index\segments_1",
+            retryCount: 3,
+            elapsed: TimeSpan.FromMilliseconds(625));
+
+        var failure = Assert.Single(scope.Events, static item => item.Name == "filesystem.operation.failed");
+        var tags = failure.Tags.ToDictionary(static item => item.Key, static item => item.Value);
+        Assert.Equal("file.move", tags["filesystem.operation"]);
+        Assert.Equal(@"C:\index\segments.tmp", tags["filesystem.path"]);
+        Assert.Equal(@"C:\index\segments_1", tags["filesystem.destination_path"]);
+        Assert.Equal(exception.HResult, tags["exception.hresult"]);
+        Assert.Equal(3, tags["retry.count"]);
+        Assert.Equal(625d, tags["elapsed.ms"]);
+    }
+
     /// <summary>
     /// Verifies the Search: Emits Activity With Query Type Tag scenario.
     /// </summary>

--- a/src/devops/Rowles.LeanCorpus.Tests.Core/Index/Integration/IndexCompatibilityTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Core/Index/Integration/IndexCompatibilityTests.cs
@@ -197,6 +197,17 @@ public sealed class IndexCompatibilityTests : IClassFixture<TestDirectoryFixture
         WriteCodecKitVersion(directory, "*.dic", 0);
 
         Assert.Throws<InvalidDataException>(() => new IndexWriter(directory, new IndexWriterConfig()));
+
+        string lockPath = Path.Combine(directory.DirectoryPath, "write.lock");
+        Assert.False(File.Exists(lockPath));
+
+        WriteCodecKitVersion(directory, "*.dic", CodecConstants.TermDictionaryVersion);
+        using (var writer = new IndexWriter(directory, new IndexWriterConfig()))
+        {
+            Assert.True(File.Exists(lockPath));
+        }
+
+        Assert.False(File.Exists(lockPath));
     }
 
     [Fact]

--- a/src/devops/Rowles.LeanCorpus.Tests.Core/Index/Integration/MergeCorrectnessTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Core/Index/Integration/MergeCorrectnessTests.cs
@@ -90,7 +90,7 @@ public sealed class MergeCorrectnessTests : IClassFixture<TestDirectoryFixture>
     [Fact(DisplayName = "Delete All Docs In One Group: After Merge Only Kept Docs Remain")]
     public void DeleteAllDocsInOneGroup_AfterMerge_OnlyKeptDocsRemain()
     {
-        var dir = new MMapDirectory(SubDir("merge_all_deleted"));
+        using var dir = new MMapDirectory(SubDir("merge_all_deleted"));
         var config = new IndexWriterConfig { MaxBufferedDocs = 1 };
 
         using (var writer = new IndexWriter(dir, config))

--- a/src/devops/Rowles.LeanCorpus.Tests.Core/Search/Integration/SearcherManagerTests.cs
+++ b/src/devops/Rowles.LeanCorpus.Tests.Core/Search/Integration/SearcherManagerTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using Rowles.LeanCorpus.Document;
 using Rowles.LeanCorpus.Tests.Shared.Fixtures;
 using Rowles.LeanCorpus.Document.Fields;
@@ -252,9 +253,11 @@ public sealed class SearcherManagerTests : IDisposable
         writer.AddDocument(Doc("second"));
         writer.Commit();
 
-        Assert.True(SpinWait.SpinUntil(
-            () => mgr.GetDiagnostics().Refreshes > 0,
-            TimeSpan.FromSeconds(5)));
+        var deadline = Stopwatch.GetTimestamp() + Stopwatch.Frequency * 5;
+        while (mgr.GetDiagnostics().Refreshes == 0 && Stopwatch.GetTimestamp() < deadline)
+            await Task.Delay(TimeSpan.FromMilliseconds(10), TestContext.Current.CancellationToken);
+
+        Assert.True(mgr.GetDiagnostics().Refreshes > 0);
         Assert.True(await mgr.MaybeRefreshAsync(TestContext.Current.CancellationToken));
     }
 


### PR DESCRIPTION
### Fixed

- Cleared pooled stored-field writer scratch before use so previous search activity cannot silently omit fields from newly written segments. (f58ac6c44)
- Released the writer lock when incompatible index metadata aborts `IndexWriter` construction, preventing Windows test-directory cleanup failures. (60b6735ea, #86)
- Synchronised merge-throttling segment inspection with background merge publication without nesting writer and merge locks, and made background-refresh coverage scheduler-friendly under stress execution. (cc3dc2aa5, 34a3c69bd, #86)
- Added structured terminal file-move and cleanup diagnostics, including paths, HRESULT, retry count, and elapsed time, and deterministically disposed the merge regression directory. (016a50aa6, #86)